### PR TITLE
Fix r_fullbright lightmap blending + add latch, description and range check

### DIFF
--- a/src/renderer/tr_init.c
+++ b/src/renderer/tr_init.c
@@ -1661,7 +1661,9 @@ static void R_Register( void )
 	//
 	// temporary latched variables that can only change over a restart
 	//
-	r_fullbright = ri.Cvar_Get( "r_fullbright", "0", CVAR_CHEAT ); // ensi note unused but some mods might expect it to exist?
+	r_fullbright = ri.Cvar_Get( "r_fullbright", "0", CVAR_CHEAT | CVAR_LATCH); // ensi note unused but some mods might expect it to exist?
+    ri.Cvar_CheckRange( r_fullbright, "0", "1", CV_INTEGER );
+    ri.Cvar_SetDescription( r_fullbright, "Use fullbright lightmaps, effectively disabling static world lighting" );
 	r_overBrightBits = ri.Cvar_Get( "r_overBrightBits", "0", CVAR_ARCHIVE_ND | CVAR_LATCH ); // Arnout: disable overbrightbits by default
 	ri.Cvar_CheckRange( r_overBrightBits, "0", "1", CV_INTEGER ); // ydnar: limit to overbrightbits 1 (sorry 1337 players)
 	ri.Cvar_SetDescription( r_overBrightBits, "Sets the intensity of overall brightness of texture pixels" );

--- a/src/renderer/tr_shader.c
+++ b/src/renderer/tr_shader.c
@@ -3521,7 +3521,7 @@ static void R_CreateDefaultShading( image_t *image ) {
 		stages[0].active = qtrue;
 		stages[0].bundle[0].image[0] = image;
 		stages[0].rgbGen = CGEN_IDENTITY_LIGHTING;
-		stages[0].stateBits = GLS_DEFAULT;
+		stages[0].stateBits = implicitStateBits;
 		break;
 
 		// explicit colors at vertexes


### PR DESCRIPTION
`r_fullbright` wasn't correctly masking lightmaps on implicitBlended/masked surfaces. Also added a missing `CVAR_LATCH` flag, as well as description and range check.