### PR TITLE
Ignore other types of cmake-build-* directories too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,7 +180,7 @@ pip-log.txt
 .idea
 [Bb]uild*/
 src/[Bb]uild*/
-cmake-build-debug
+cmake-build-*
 src/scons.signatures.dblite
 site.conf
 src/et.x86


### PR DESCRIPTION
Such as `cmake-build-release` and `cmake-build_relwithdebinfo`