### PR TITLE
Allow setting SDL audiodriver with s_sdlDriver

### DIFF
--- a/src/client/snd_dma.c
+++ b/src/client/snd_dma.c
@@ -110,6 +110,10 @@ static cvar_t *s_mixOffset;
 cvar_t		*s_device;
 #endif
 
+#if defined(USE_SDL)
+cvar_t		*s_sdlDriver;
+#endif
+
 cvar_t *s_debugStreams;
 
 // fretn
@@ -2451,6 +2455,11 @@ qboolean S_Base_Init( soundInterface_t *si ) {
 	s_device = Cvar_Get( "s_device", "default", CVAR_ARCHIVE_ND | CVAR_LATCH );
 	Cvar_SetDescription( s_device, "Set SDL audio output device index\n"
 		"Use \"default\" to let system pick or choose one from \\s_devlist output." );
+#endif
+
+#if defined(USE_SDL)
+	s_sdlDriver = Cvar_Get( "s_sdlDriver", "", CVAR_ARCHIVE_ND | CVAR_LATCH | CVAR_UNSAFE );
+	Cvar_SetDescription( s_sdlDriver, "Set SDL audio driver, e.g. \"pulseaudio\" or \"pipewire\"" );
 #endif
 
 	s_debugStreams = Cvar_Get("s_debugStreams", "0", CVAR_TEMP);

--- a/src/client/snd_local.h
+++ b/src/client/snd_local.h
@@ -261,6 +261,10 @@ extern cvar_t *s_muteWhenUnfocused;
 
 extern cvar_t *s_testsound;
 
+#if defined(USE_SDL)
+extern cvar_t *s_sdlDriver;
+#endif
+
 extern float s_volCurrent;
 
 qboolean S_LoadSound( sfx_t *sfx );

--- a/src/sdl/sdl_snd.c
+++ b/src/sdl/sdl_snd.c
@@ -253,6 +253,13 @@ qboolean SNDDMA_Init( void )
 	s_sdlLevelSamps = Cvar_Get( "s_sdlLevelSamps", "0", CVAR_ARCHIVE_ND | CVAR_LATCH );
 	Cvar_CheckRange( s_sdlLevelSamps, "0", "2", CV_INTEGER );
 
+#if defined(USE_SDL)
+	if ( s_sdlDriver->string )
+	{
+		SDL_setenv("SDL_AUDIODRIVER", s_sdlDriver->string, 0);
+	}
+#endif
+
 	Com_Printf( "SDL_Init( SDL_INIT_AUDIO )... " );
 
 	if ( SDL_Init( SDL_INIT_AUDIO ) != 0 )


### PR DESCRIPTION
Similar to how `r_sdlDriver` can be used to set `SDL_VIDEODRIVER` environmental variable, allow the same for `SDL_AUDIODRIVER` with `s_sdlDriver`.