### PR TITLE
Fix memory leak on vulkan renderer

### DIFF
--- a/src/renderervk/tr_init.c
+++ b/src/renderervk/tr_init.c
@@ -2244,12 +2244,12 @@ static void RE_Shutdown( refShutdownCode_t code ) {
 
 	if ( r_cache->integer ) {
 		if ( tr.registered ) {
+#ifdef USE_VULKAN
+			vk_release_resources();
+#endif
 			if ( code != REF_KEEP_CONTEXT ) {
 				//R_IssuePendingRenderCommands();
 				R_DeleteTextures();
-#ifdef USE_VULKAN
-				vk_release_resources();
-#endif
 			} else {
 				// backup the current media
 


### PR DESCRIPTION
If `r_cache` was set to 1, and `RE_Shutdown` was called with `REF_KEEP_CONTEXT` (such as when loading a new map), `vk_release_resources` would never get called, causing memory leak.