### PR TITLE
Don't increment sv.time before VM_Call

### DIFF
--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -387,8 +387,8 @@ static void SV_MapRestart_f( void ) {
 
 	// run a few frames to allow everything to settle
 	for ( i = 0; i < GAME_INIT_FRAMES; i++ ) {
-		sv.time += FRAMETIME;
 		VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+		sv.time += FRAMETIME;
 	}
 
 	sv.state = SS_GAME;
@@ -437,8 +437,8 @@ static void SV_MapRestart_f( void ) {
 		}
 	}	
 	// run another frame to allow things to look at all the players
-	sv.time += FRAMETIME;
 	VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+	sv.time += FRAMETIME;
 	svs.time += FRAMETIME;
 
 	Cvar_Set( "sv_serverRestarting", "0" );

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -701,8 +701,8 @@ void SV_SpawnServer( const char *mapname ) {
 	// run a few frames to allow everything to settle
 	for ( i = 0 ; i < GAME_INIT_FRAMES ; i++ )
 	{
-		sv.time += FRAMETIME;
 		VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+        sv.time += FRAMETIME;
 		////SV_BotFrame (sv.time);
 	}
 
@@ -757,8 +757,8 @@ void SV_SpawnServer( const char *mapname ) {
 	}
 
 	// run another frame to allow things to look at all the players
-	sv.time += FRAMETIME;
 	VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+	sv.time += FRAMETIME;
 	////SV_BotFrame( sv.time );
 	svs.time += FRAMETIME;
 


### PR DESCRIPTION
Doing this causes timing issues with mapscripts since mapscript commands aren't executed immediately when level is loaded. This will cause a div by 0 in `G_RunEntity` in qagame code, but this is the way 2.60b worked, and mapscripts are made to work with this timing.