### PR TITLE
Fix 64-bit calling convention on Windows

### DIFF
--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -235,7 +235,7 @@ static void CL_SetClientLerpOrigin( float x, float y, float z ) {
 
 qboolean CL_CGameCheckKeyExec( int key ) {
 	if ( cgvm ) {
-		return VM_Call( cgvm, 1, CG_CHECKEXECKEY, key );
+		return VM_Call( cgvm, CG_CHECKEXECKEY, key );
 	} else {
 		return qfalse;
 	}
@@ -421,7 +421,7 @@ rescan:
 	if ( !strcmp( cmd, "popup" ) ) { // direct server to client popup request, bypassing cgame
 //		trap_UI_Popup(Cmd_Argv(1));
 //		if ( cls.state == CA_ACTIVE && !clc.demoplaying ) {
-//			VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_CLIPBOARD);
+//			VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_CLIPBOARD);
 //			Menus_OpenByName(Cmd_Argv(1));
 //		}
 		return qfalse;
@@ -542,7 +542,7 @@ void CL_CGameBinaryMessageReceived( const char *buf, int buflen, int serverTime 
 	// TODO error instead or is this sufficient?
 	if ( !cgvm )
 		return;
-	VM_Call( cgvm, 3, CG_MESSAGERECEIVED, buf, buflen, serverTime );
+	VM_Call( cgvm, CG_MESSAGERECEIVED, buf, buflen, serverTime );
 }
 
 /*
@@ -584,7 +584,7 @@ void CL_ShutdownCGame( void ) {
 		return;
 	}
 
-	VM_Call( cgvm, 0, CG_SHUTDOWN );
+	VM_Call( cgvm, CG_SHUTDOWN );
 	VM_Free( cgvm );
 	cgvm = NULL;
 	Cmd_UnregisterModule( MODULE_CGAME );
@@ -1094,7 +1094,7 @@ static intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 	case CG_INGAME_POPUP:
 		if ( cls.state == CA_ACTIVE && !clc.demoplaying ) {
 			if ( uivm ) { // Gordon: can be called as the system is shutting down
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, args[1] );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, args[1] );
 			}
 		}
 		return 0;
@@ -1345,10 +1345,10 @@ void CL_InitCGame( void ) {
 	// otherwise server commands sent just before a gamestate are dropped
 	//bani - added clc.demoplaying, since some mods need this at init time, and drawactiveframe is too late for them
 	if ( currentGameMod == GAMEMOD_LEGACY ) {
-		VM_Call( cgvm, 7, CG_INIT, clc.serverMessageSequence, clc.lastExecutedServerCommand, clc.clientNum, clc.demoplaying, qtrue, NULL, com_legacyVersion->integer );
+		VM_Call( cgvm, CG_INIT, clc.serverMessageSequence, clc.lastExecutedServerCommand, clc.clientNum, clc.demoplaying, qtrue, NULL, com_legacyVersion->integer );
 	}
 	else {
-		VM_Call( cgvm, 4, CG_INIT, clc.serverMessageSequence, clc.lastExecutedServerCommand, clc.clientNum, clc.demoplaying );
+		VM_Call( cgvm, CG_INIT, clc.serverMessageSequence, clc.lastExecutedServerCommand, clc.clientNum, clc.demoplaying );
 	}
 
 	// reset any CVAR_CHEAT cvars registered by cgame
@@ -1398,7 +1398,7 @@ qboolean CL_GameCommand( void ) {
 		return qfalse;
 	}
 
-	bRes = (qboolean)VM_Call( cgvm, 0, CG_CONSOLE_COMMAND );
+	bRes = (qboolean)VM_Call( cgvm, CG_CONSOLE_COMMAND );
 
 	Cbuf_NestedReset();
 
@@ -1412,7 +1412,7 @@ CL_CGameRendering
 =====================
 */
 void CL_CGameRendering( stereoFrame_t stereo ) {
-	VM_Call( cgvm, 3, CG_DRAW_ACTIVE_FRAME, cl.serverTime, stereo, clc.demoplaying );
+	VM_Call( cgvm, CG_DRAW_ACTIVE_FRAME, cl.serverTime, stereo, clc.demoplaying );
 #ifdef _DEBUG
 	VM_Debug( 0 );
 #endif
@@ -1714,7 +1714,7 @@ qboolean CL_GetTag( int clientNum, char *tagname, orientation_t *orientation ) {
 		return qfalse;
 	}
 
-	return VM_Call( cgvm, 3, CG_GET_TAG, clientNum, tagname, orientation );
+	return VM_Call( cgvm, CG_GET_TAG, clientNum, tagname, orientation );
 }
 
 qboolean CL_CgameRunning( void ) {

--- a/src/client/cl_cin.c
+++ b/src/client/cl_cin.c
@@ -1502,7 +1502,7 @@ int CIN_PlayCinematic( const char *arg, int x, int y, int w, int h, int systemBi
 	if ( cinTable[currentHandle].alterGameState ) {
 		// close the menu
 		if ( uivm ) {
-			VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_NONE );
+			VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_NONE );
 		}
 	} else {
 		cinTable[currentHandle].playonwalls = cl_inGameVideo->integer;

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -436,7 +436,7 @@ void CL_MouseEvent( int dx, int dy /*, int time*/ ) {
 			cl.mouseDx[cl.mouseIndex] += dx;
 			cl.mouseDy[cl.mouseIndex] += dy;
 		} else {
-			VM_Call( uivm, 2, UI_MOUSE_EVENT, dx, dy );
+			VM_Call( uivm, UI_MOUSE_EVENT, dx, dy );
 		}
 
 	} else if ( Key_GetCatcher() & KEYCATCH_CGAME ) {
@@ -444,7 +444,7 @@ void CL_MouseEvent( int dx, int dy /*, int time*/ ) {
 			cl.mouseDx[cl.mouseIndex] += dx;
 			cl.mouseDy[cl.mouseIndex] += dy;
 		} else {
-			VM_Call( cgvm, 2, CG_MOUSE_EVENT, dx, dy );
+			VM_Call( cgvm, CG_MOUSE_EVENT, dx, dy );
 		}
 	} else {
 		cl.mouseDx[cl.mouseIndex] += dx;

--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -681,13 +681,13 @@ static void CL_KeyDownEvent( int key, unsigned time )
 		// escape always gets out of CGAME stuff
 		if (Key_GetCatcher( ) & KEYCATCH_CGAME) {
 			Key_SetCatcher( Key_GetCatcher( ) & ~KEYCATCH_CGAME );
-			VM_Call( cgvm, 1, CG_EVENT_HANDLING, CGAME_EVENT_NONE );
+			VM_Call( cgvm, CG_EVENT_HANDLING, CGAME_EVENT_NONE );
 			return;
 		}
 
 		if ( !( Key_GetCatcher( ) & KEYCATCH_UI ) ) {
 			if ( cls.state == CA_ACTIVE && !clc.demoplaying ) {
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_INGAME );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_INGAME );
 			}
 			else if ( cls.state != CA_DISCONNECTED ) {
 #if 0
@@ -702,12 +702,12 @@ static void CL_KeyDownEvent( int key, unsigned time )
 					CL_FlushMemory();
 				}
 #endif
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 			}
 			return;
 		}
 
-		VM_Call( uivm, 2, UI_KEY_EVENT, key, qtrue );
+		VM_Call( uivm, UI_KEY_EVENT, key, qtrue );
 		return;
 	}
 
@@ -730,12 +730,12 @@ static void CL_KeyDownEvent( int key, unsigned time )
 			Console_Key( key );
 		}
 	} else if ( (Key_GetCatcher() & KEYCATCH_UI) && uivm && !bypassMenu ) {
-		if ( !onlybinds || VM_Call( uivm, 0, UI_WANTSBINDKEYS ) ) {
-			VM_Call( uivm, 2, UI_KEY_EVENT, key, qtrue );
+		if ( !onlybinds || VM_Call( uivm, UI_WANTSBINDKEYS ) ) {
+			VM_Call( uivm, UI_KEY_EVENT, key, qtrue );
 		}
 	} else if ( (Key_GetCatcher() & KEYCATCH_CGAME) && cgvm && !bypassMenu ) {
-		if ( !onlybinds || VM_Call( cgvm, 0, CG_WANTSBINDKEYS ) ) {
-			VM_Call( cgvm, 2, CG_KEY_EVENT, key, qtrue );
+		if ( !onlybinds || VM_Call( cgvm, CG_WANTSBINDKEYS ) ) {
+			VM_Call( cgvm, CG_KEY_EVENT, key, qtrue );
 		}
 	} else if ( Key_GetCatcher() & KEYCATCH_MESSAGE ) {
 		if ( !onlybinds ) {
@@ -799,12 +799,12 @@ static void CL_KeyUpEvent( int key, unsigned time )
 	}
 
 	if ( Key_GetCatcher( ) & KEYCATCH_UI && uivm ) {
-		if ( !onlybinds || VM_Call( uivm, 0, UI_WANTSBINDKEYS ) ) {
-			VM_Call( uivm, 2, UI_KEY_EVENT, key, qfalse );
+		if ( !onlybinds || VM_Call( uivm, UI_WANTSBINDKEYS ) ) {
+			VM_Call( uivm, UI_KEY_EVENT, key, qfalse );
 		}
 	} else if ( Key_GetCatcher( ) & KEYCATCH_CGAME && cgvm ) {
-		if ( !onlybinds || VM_Call( cgvm, 0, CG_WANTSBINDKEYS ) ) {
-			VM_Call( cgvm, 2, CG_KEY_EVENT, key, qfalse );
+		if ( !onlybinds || VM_Call( cgvm, CG_WANTSBINDKEYS ) ) {
+			VM_Call( cgvm, CG_KEY_EVENT, key, qfalse );
 		}
 	}
 }
@@ -847,11 +847,11 @@ void CL_CharEvent( int key )
 	}
 	else if ( Key_GetCatcher( ) & KEYCATCH_UI )
 	{
-		VM_Call( uivm, 2, UI_KEY_EVENT, key | K_CHAR_FLAG, qtrue );
+		VM_Call( uivm, UI_KEY_EVENT, key | K_CHAR_FLAG, qtrue );
 	}
 	else if ( Key_GetCatcher( ) & KEYCATCH_CGAME )
 	{
-		VM_Call( cgvm, 2, CG_KEY_EVENT, key | K_CHAR_FLAG, qtrue );
+		VM_Call( cgvm, CG_KEY_EVENT, key | K_CHAR_FLAG, qtrue );
 	}
 	else if ( Key_GetCatcher( ) & KEYCATCH_MESSAGE )
 	{

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1429,7 +1429,7 @@ qboolean CL_Disconnect( qboolean showMainMenu ) {
 	Key_ClearStates();
 
 	if ( uivm && showMainMenu ) {
-		VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_NONE );
+		VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_NONE );
 	}
 
 	// Remove pure paks
@@ -1616,7 +1616,7 @@ void CL_Disconnect_f( void ) {
 				CL_FlushMemory();
 			}
 			if ( uivm ) {
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 			}
 		}
 	}
@@ -3116,7 +3116,7 @@ static void CL_CheckTimeout( void ) {
 				CL_FlushMemory();
 			}
 			if ( uivm ) {
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 			}
 			return;
 		}
@@ -3335,12 +3335,12 @@ void CL_Frame( int msec, int realMsec ) {
 	if ( cls.cddialog ) {
 		// bring up the cd error dialog if needed
 		cls.cddialog = qfalse;
-		VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_NEED_CD );
+		VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_NEED_CD );
 	} else	if ( cls.state == CA_DISCONNECTED && !( Key_GetCatcher( ) & KEYCATCH_UI )
 		&& !com_sv_running->integer && uivm ) {
 		// if disconnected, bring up the menu
 		S_StopAllSounds();
-		VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+		VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 	}
 
 	aviRecord = CL_VideoRecording();

--- a/src/client/cl_scrn.c
+++ b/src/client/cl_scrn.c
@@ -526,7 +526,7 @@ static void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 
 	re.BeginFrame( stereoFrame );
 
-	uiFullscreen = (uivm && VM_Call( uivm, 0, UI_IS_FULLSCREEN ));
+	uiFullscreen = (uivm && VM_Call( uivm, UI_IS_FULLSCREEN ));
 
 	// wide aspect ratio screens need to have the sides cleared
 	// unless they are displaying game renderings
@@ -556,20 +556,20 @@ static void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 		case CA_DISCONNECTED:
 			// force menu up
 			S_StopAllSounds();
-			VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+			VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 			break;
 		case CA_CONNECTING:
 		case CA_CHALLENGING:
 		case CA_CONNECTED:
 			// connecting clients will only show the connection dialog
 			// refresh to update the time
-			VM_Call( uivm, 1, UI_REFRESH, cls.realtime );
-			VM_Call( uivm, 1, UI_DRAW_CONNECT_SCREEN, qfalse );
+			VM_Call( uivm, UI_REFRESH, cls.realtime );
+			VM_Call( uivm, UI_DRAW_CONNECT_SCREEN, qfalse );
 			break;
 //			// Ridah, if the cgame is valid, fall through to there
 //			if (!cls.cgameStarted || !com_sv_running->integer) {
 //				// connecting clients will only show the connection dialog
-//				VM_Call( uivm, 1, UI_DRAW_CONNECT_SCREEN, qfalse );
+//				VM_Call( uivm, UI_DRAW_CONNECT_SCREEN, qfalse );
 //				break;
 //			}
 		case CA_LOADING:
@@ -581,8 +581,8 @@ static void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 			// also draw the connection information, so it doesn't
 			// flash away too briefly on local or lan games
 			// refresh to update the time
-			VM_Call( uivm, 1, UI_REFRESH, cls.realtime );
-			VM_Call( uivm, 1, UI_DRAW_CONNECT_SCREEN, qtrue );
+			VM_Call( uivm, UI_REFRESH, cls.realtime );
+			VM_Call( uivm, UI_DRAW_CONNECT_SCREEN, qtrue );
 			break;
 		case CA_ACTIVE:
 			// always supply STEREO_CENTER as vieworg offset is now done by the engine.
@@ -597,7 +597,7 @@ static void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 
 	// the menu draws next
 	if ( (Key_GetCatcher( ) & KEYCATCH_UI) && uivm ) {
-		VM_Call( uivm, 1, UI_REFRESH, cls.realtime );
+		VM_Call( uivm, UI_REFRESH, cls.realtime );
 	}
 
 	// console draws next

--- a/src/client/cl_ui.c
+++ b/src/client/cl_ui.c
@@ -1359,7 +1359,7 @@ void CL_ShutdownUI( void ) {
 	if ( !uivm ) {
 		return;
 	}
-	VM_Call( uivm, 0, UI_SHUTDOWN );
+	VM_Call( uivm, UI_SHUTDOWN );
 	VM_Free( uivm );
 	uivm = NULL;
 	Cmd_UnregisterModule( MODULE_UI );
@@ -1397,7 +1397,7 @@ void CL_InitUI( void ) {
 	}
 
 	// sanity check
-	v = VM_Call( uivm, 0, UI_GETAPIVERSION );
+	v = VM_Call( uivm, UI_GETAPIVERSION );
 	if ( v != UI_API_VERSION ) {
 		// Free uivm now, so UI_SHUTDOWN doesn't get called later.
 		VM_Free( uivm );
@@ -1409,16 +1409,16 @@ void CL_InitUI( void ) {
 	else {
 		// init for this gamestate
 		if ( currentGameMod == GAMEMOD_LEGACY || currentGameMod == GAMEMOD_ETJUMP )
-			VM_Call( uivm, 3, UI_INIT, ( cls.state >= CA_AUTHORIZING && cls.state < CA_ACTIVE ), qtrue, com_legacyVersion->integer );
+			VM_Call( uivm, UI_INIT, ( cls.state >= CA_AUTHORIZING && cls.state < CA_ACTIVE ), qtrue, com_legacyVersion->integer );
 		else
-			VM_Call( uivm, 1, UI_INIT, ( cls.state >= CA_AUTHORIZING && cls.state < CA_ACTIVE ) );
+			VM_Call( uivm, UI_INIT, ( cls.state >= CA_AUTHORIZING && cls.state < CA_ACTIVE ) );
 	}
 }
 
 
 qboolean UI_usesUniqueCDKey() {
 	if ( uivm ) {
-		return ( VM_Call( uivm, 0, UI_HASUNIQUECDKEY ) == qtrue );
+		return ( VM_Call( uivm, UI_HASUNIQUECDKEY ) == qtrue );
 	} else {
 		return qfalse;
 	}
@@ -1426,7 +1426,7 @@ qboolean UI_usesUniqueCDKey() {
 
 qboolean UI_checkKeyExec( int key ) {
 	if ( uivm ) {
-		return VM_Call( uivm, 1, UI_CHECKEXECKEY, key );
+		return VM_Call( uivm, UI_CHECKEXECKEY, key );
 	} else {
 		return qfalse;
 	}
@@ -1444,5 +1444,5 @@ qboolean UI_GameCommand( void ) {
 		return qfalse;
 	}
 
-	return VM_Call( uivm, 1, UI_CONSOLE_COMMAND, cls.realtime );
+	return VM_Call( uivm, UI_CONSOLE_COMMAND, cls.realtime );
 }

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -434,7 +434,9 @@ void	VM_Forced_Unload_Start(void);
 void	VM_Forced_Unload_Done(void);
 vm_t	*VM_Restart( vm_t *vm );
 
-intptr_t	QDECL VM_Call( vm_t *vm, int nargs, int callNum, ... );
+#define		VM_CALL_END (-1337)
+intptr_t	QDECL VM_CallFunc(vm_t* vm, int callNum, ...);
+#define		VM_Call(...) VM_CallFunc(__VA_ARGS__, VM_CALL_END)
 
 void	VM_Debug( int level );
 

--- a/src/qcommon/vm.c
+++ b/src/qcommon/vm.c
@@ -301,7 +301,7 @@ locals from sp
 ==============
 */
 
-intptr_t QDECL VM_Call( vm_t *vm, int nargs, int callnum, ... )
+intptr_t QDECL VM_CallFunc( vm_t *vm, int callnum, ... )
 {
 	intptr_t r = 0;
 	int i;
@@ -314,10 +314,6 @@ intptr_t QDECL VM_Call( vm_t *vm, int nargs, int callnum, ... )
 	if ( vm_debugLevel ) {
 		Com_Printf( "VM_Call( %d )\n", callnum );
 	}
-
-	if ( nargs >= MAX_VMMAIN_CALL_ARGS ) {
-		Com_Error( ERR_DROP, "VM_Call: nargs >= MAX_VMMAIN_CALL_ARGS" );
-	}
 #endif
 
 	++vm->callLevel;
@@ -325,11 +321,16 @@ intptr_t QDECL VM_Call( vm_t *vm, int nargs, int callnum, ... )
 	if ( vm->entryPoint ) 
 	{
 		//rcg010207 -  see dissertation at top of VM_DllSyscall() in this file.
-		intptr_t args[MAX_VMMAIN_CALL_ARGS-1] = { 0 };
+		intptr_t args[MAX_VMMAIN_CALL_ARGS] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 		va_list ap;
 		va_start( ap, callnum );
-		for ( i = 0; i < nargs; i++ ) {
+		for ( i = 0; i < ARRAY_LEN(args); i++ ) {
 			args[i] = va_arg( ap, intptr_t );
+
+			if (VM_CALL_END == (int)args[i]) {
+				args[i] = 0;
+				break;
+			}
 		}
 		va_end(ap);
 

--- a/src/server/sv_bot.c
+++ b/src/server/sv_bot.c
@@ -118,7 +118,7 @@ SV_BotFrame
 	if ( !gvm ) {
 		return;
 	}
-	VM_Call( gvm, 1, BOTAI_START_FRAME, time );
+	VM_Call( gvm, BOTAI_START_FRAME, time );
 }*/
 
 

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -387,7 +387,7 @@ static void SV_MapRestart_f( void ) {
 
 	// run a few frames to allow everything to settle
 	for ( i = 0; i < GAME_INIT_FRAMES; i++ ) {
-		VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+		VM_Call( gvm, GAME_RUN_FRAME, sv.time );
 		sv.time += FRAMETIME;
 	}
 
@@ -416,7 +416,7 @@ static void SV_MapRestart_f( void ) {
 		SV_AddServerCommand( client, "map_restart\n" );
 
 		// connect the client again, without the firstTime flag
-		denied = GVM_ArgPtr( VM_Call( gvm, 3, GAME_CLIENT_CONNECT, i, qfalse, isBot ) );
+		denied = GVM_ArgPtr( VM_Call( gvm, GAME_CLIENT_CONNECT, i, qfalse, isBot ) );
 		if ( denied ) {
 			// this generally shouldn't happen, because the client
 			// was connected before the level change
@@ -437,7 +437,7 @@ static void SV_MapRestart_f( void ) {
 		}
 	}	
 	// run another frame to allow things to look at all the players
-	VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+	VM_Call( gvm, GAME_RUN_FRAME, sv.time );
 	sv.time += FRAMETIME;
 	svs.time += FRAMETIME;
 

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -686,7 +686,7 @@ void SV_DirectConnect( const netadr_t *from ) {
 
 //			// disconnect the client from the game first so any flags the
 //			// player might have are dropped
-//			VM_Call( gvm, 1, GAME_CLIENT_DISCONNECT, newcl - svs.clients );
+//			VM_Call( gvm, GAME_CLIENT_DISCONNECT, newcl - svs.clients );
 			//
 			goto gotnewcl;
 		}
@@ -790,7 +790,7 @@ gotnewcl:
 	}
 
 	// get the game a chance to reject this connection or modify the userinfo
-	denied = VM_Call( gvm, 3, GAME_CLIENT_CONNECT, clientNum, qtrue, qfalse ); // firstTime = qtrue
+	denied = VM_Call( gvm, GAME_CLIENT_CONNECT, clientNum, qtrue, qfalse ); // firstTime = qtrue
 	if ( denied ) {
 		// we can't just use VM_ArgPtr, because that is only valid inside a VM_Call
 		const char *str = GVM_ArgPtr( denied );
@@ -890,7 +890,7 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 
 	// call the prog function for removing a client
 	// this will remove the body, among other things
-	VM_Call( gvm, 1, GAME_CLIENT_DISCONNECT, drop - svs.clients );
+	VM_Call( gvm, GAME_CLIENT_DISCONNECT, drop - svs.clients );
 
 	// add the disconnect command
 	if ( reason ) {
@@ -1149,7 +1149,7 @@ void SV_ClientEnterWorld( client_t *client, usercmd_t *cmd ) {
 		memset(&client->lastUsercmd, '\0', sizeof(client->lastUsercmd));
 
 	// call the game begin function
-	VM_Call( gvm, 1, GAME_CLIENT_BEGIN, client - svs.clients );
+	VM_Call( gvm, GAME_CLIENT_BEGIN, client - svs.clients );
 }
 
 
@@ -2026,7 +2026,7 @@ static void SV_UpdateUserinfo_f( client_t *cl ) {
 
 	SV_UserinfoChanged( cl, qtrue, qtrue ); // update userinfo, run filter
 	// call prog code to allow overrides
-	VM_Call( gvm, 1, GAME_CLIENT_USERINFO_CHANGED, cl - svs.clients );
+	VM_Call( gvm, GAME_CLIENT_USERINFO_CHANGED, cl - svs.clients );
 }
 
 extern int SV_Strlen( const char *str );
@@ -2213,7 +2213,7 @@ qboolean SV_ExecuteClientCommand( client_t *cl, const char *s, qboolean premapre
 				else
 					Cmd_Args_Sanitize( "\n\r", qtrue );
 			}
-			VM_Call( gvm, 1, GAME_CLIENT_COMMAND, cl - svs.clients );
+			VM_Call( gvm, GAME_CLIENT_COMMAND, cl - svs.clients );
 		}
 	}
 
@@ -2275,7 +2275,7 @@ void SV_ClientThink (client_t *cl, usercmd_t *cmd) {
 		return;		// may have been kicked during the last usercmd
 	}
 
-	VM_Call( gvm, 1, GAME_CLIENT_THINK, cl - svs.clients );
+	VM_Call( gvm, GAME_CLIENT_THINK, cl - svs.clients );
 }
 
 

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -356,14 +356,14 @@ SV_GameBinaryMessageReceived
 void SV_GameBinaryMessageReceived( int cno, const char *buf, int buflen, int commandTime ) {
 	if ( !gvm )
 		return;
-	VM_Call( gvm, 4, GAME_MESSAGERECEIVED, cno, buf, buflen, commandTime );
+	VM_Call( gvm, GAME_MESSAGERECEIVED, cno, buf, buflen, commandTime );
 }
 
 
 qboolean SV_GameSnapshotCallback( int entityNum, int clientNum ) {
 	if ( !gvm )
 		return qtrue;
-	return VM_Call( gvm, 2, GAME_SNAPSHOT_CALLBACK, entityNum, clientNum );
+	return VM_Call( gvm, GAME_SNAPSHOT_CALLBACK, entityNum, clientNum );
 }
 
 
@@ -754,7 +754,7 @@ void SV_ShutdownGameProgs( void ) {
 
 	//Sys_OmnibotUnLoad();
 
-	VM_Call( gvm, 1, GAME_SHUTDOWN, qfalse );
+	VM_Call( gvm, GAME_SHUTDOWN, qfalse );
 	VM_Free( gvm );
 	gvm = NULL;
 	Cmd_UnregisterModule( MODULE_SGAME );
@@ -790,9 +790,9 @@ static void SV_InitGameVM( qboolean restart ) {
 	// use the current msec count for a random seed
 	// init for this gamestate
 	if ( currentGameMod == GAMEMOD_LEGACY )
-		VM_Call( gvm, 5, GAME_INIT, sv.time, Com_Milliseconds(), restart, qtrue, com_legacyVersion->integer );
+		VM_Call( gvm, GAME_INIT, sv.time, Com_Milliseconds(), restart, qtrue, com_legacyVersion->integer );
 	else
-		VM_Call( gvm, 3, GAME_INIT, sv.time, Com_Milliseconds(), restart );
+		VM_Call( gvm, GAME_INIT, sv.time, Com_Milliseconds(), restart );
 }
 
 
@@ -811,7 +811,7 @@ void SV_RestartGameProgs( void ) {
 	// unload the refs during a restart
 	//Sys_OmnibotUnLoad();
 
-	VM_Call( gvm, 1, GAME_SHUTDOWN, qtrue );
+	VM_Call( gvm, GAME_SHUTDOWN, qtrue );
 
 	// do a restart instead of a free
 	gvm = VM_Restart( gvm );
@@ -865,7 +865,7 @@ qboolean SV_GameCommand( void ) {
 		return qfalse;
 	}
 
-	return VM_Call( gvm, 0, GAME_CONSOLE_COMMAND );
+	return VM_Call( gvm, GAME_CONSOLE_COMMAND );
 }
 
 /*

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -701,7 +701,7 @@ void SV_SpawnServer( const char *mapname ) {
 	// run a few frames to allow everything to settle
 	for ( i = 0 ; i < GAME_INIT_FRAMES ; i++ )
 	{
-		VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+		VM_Call( gvm, GAME_RUN_FRAME, sv.time );
         sv.time += FRAMETIME;
 		////SV_BotFrame (sv.time);
 	}
@@ -726,7 +726,7 @@ void SV_SpawnServer( const char *mapname ) {
 			}
 
 			// connect the client again
-			denied = GVM_ArgPtr( VM_Call( gvm, 3, GAME_CLIENT_CONNECT, i, qfalse, isBot ) );	// firstTime = qfalse
+			denied = GVM_ArgPtr( VM_Call( gvm, GAME_CLIENT_CONNECT, i, qfalse, isBot ) );	// firstTime = qfalse
 			if ( denied ) {
 				// this generally shouldn't happen, because the client
 				// was connected before the level change
@@ -750,14 +750,14 @@ void SV_SpawnServer( const char *mapname ) {
 					client->deltaMessage = client->netchan.outgoingSequence - ( PACKET_BACKUP + 1 ); // force delta reset
 					client->lastSnapshotTime = svs.time - 9999; // generate a snapshot immediately
 
-					VM_Call( gvm, 1, GAME_CLIENT_BEGIN, i );
+					VM_Call( gvm, GAME_CLIENT_BEGIN, i );
 				}
 			}
 		}
 	}
 
 	// run another frame to allow things to look at all the players
-	VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+	VM_Call( gvm, GAME_RUN_FRAME, sv.time );
 	sv.time += FRAMETIME;
 	////SV_BotFrame( sv.time );
 	svs.time += FRAMETIME;

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1669,7 +1669,7 @@ void SV_Frame( int msec ) {
 		sv.time += frameMsec;
 
 		// let everything in the world think and move
-		VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+		VM_Call( gvm, GAME_RUN_FRAME, sv.time );
 	}
 
 	if ( com_speeds->integer ) {


### PR DESCRIPTION
On 64-bit, `va_arg` does not pass in all arguments via stack, instead some are passed in via registers. GCC/Clang expand these correctly to the argument list, but MSVC does some funky shit and would require some manual macro hell to correctly expand the arguments from registers to the `va_arg` call. By doing `VM_Call` like this, we avoid passing in random integers to mod in `vmMain` arguments.

https://blog.nelhage.com/2010/10/amd64-and-va_arg/