### PR TITLE
Fix VM_Call/syscall argument expansion on 64-bit

### DIFF
--- a/src/cgame/cg_syscalls.c
+++ b/src/cgame/cg_syscalls.c
@@ -46,401 +46,401 @@ void trap_PumpEventLoop( void ) {
 	if ( !cgs.initing ) {
 		return;
 	}
-	syscall( CG_PUMPEVENTLOOP );
+	SystemCall( CG_PUMPEVENTLOOP );
 }
 
 
 void    trap_Print( const char *fmt ) {
-	syscall( CG_PRINT, fmt );
+	SystemCall( CG_PRINT, fmt );
 }
 
 void   NORETURN trap_Error( const char *fmt ) {
-	syscall( CG_ERROR, fmt );
+	SystemCall( CG_ERROR, fmt );
 	exit( 1 );
 }
 
 int     trap_Milliseconds( void ) {
-	return syscall( CG_MILLISECONDS );
+	return SystemCall( CG_MILLISECONDS );
 }
 
 void    trap_Cvar_Register( vmCvar_t *vmCvar, const char *varName, const char *defaultValue, int flags ) {
-	syscall( CG_CVAR_REGISTER, vmCvar, varName, defaultValue, flags );
+	SystemCall( CG_CVAR_REGISTER, vmCvar, varName, defaultValue, flags );
 }
 
 void    trap_Cvar_Update( vmCvar_t *vmCvar ) {
-	syscall( CG_CVAR_UPDATE, vmCvar );
+	SystemCall( CG_CVAR_UPDATE, vmCvar );
 }
 
 void    trap_Cvar_Set( const char *var_name, const char *value ) {
-	syscall( CG_CVAR_SET, var_name, value );
+	SystemCall( CG_CVAR_SET, var_name, value );
 }
 
 void trap_Cvar_VariableStringBuffer( const char *var_name, char *buffer, int bufsize ) {
-	syscall( CG_CVAR_VARIABLESTRINGBUFFER, var_name, buffer, bufsize );
+	SystemCall( CG_CVAR_VARIABLESTRINGBUFFER, var_name, buffer, bufsize );
 }
 
 void trap_Cvar_LatchedVariableStringBuffer( const char *var_name, char *buffer, int bufsize ) {
-	syscall( CG_CVAR_LATCHEDVARIABLESTRINGBUFFER, var_name, buffer, bufsize );
+	SystemCall( CG_CVAR_LATCHEDVARIABLESTRINGBUFFER, var_name, buffer, bufsize );
 }
 
 int trap_Argc( void ) {
-	return syscall( CG_ARGC );
+	return SystemCall( CG_ARGC );
 }
 
 void    trap_Argv( int n, char *buffer, int bufferLength ) {
-	syscall( CG_ARGV, n, buffer, bufferLength );
+	SystemCall( CG_ARGV, n, buffer, bufferLength );
 }
 
 void    trap_Args( char *buffer, int bufferLength ) {
-	syscall( CG_ARGS, buffer, bufferLength );
+	SystemCall( CG_ARGS, buffer, bufferLength );
 }
 
 int     trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode ) {
-	return syscall( CG_FS_FOPENFILE, qpath, f, mode );
+	return SystemCall( CG_FS_FOPENFILE, qpath, f, mode );
 }
 
 void    trap_FS_Read( void *buffer, int len, fileHandle_t f ) {
-	syscall( CG_FS_READ, buffer, len, f );
+	SystemCall( CG_FS_READ, buffer, len, f );
 }
 
 void    trap_FS_Write( const void *buffer, int len, fileHandle_t f ) {
-	syscall( CG_FS_WRITE, buffer, len, f );
+	SystemCall( CG_FS_WRITE, buffer, len, f );
 }
 
 void    trap_FS_FCloseFile( fileHandle_t f ) {
-	syscall( CG_FS_FCLOSEFILE, f );
+	SystemCall( CG_FS_FCLOSEFILE, f );
 }
 
 int trap_FS_GetFileList(  const char *path, const char *extension, char *listbuf, int bufsize ) {
-	return syscall( CG_FS_GETFILELIST, path, extension, listbuf, bufsize );
+	return SystemCall( CG_FS_GETFILELIST, path, extension, listbuf, bufsize );
 }
 
 int trap_FS_Delete( const char *filename ) {
-	return syscall( CG_FS_DELETEFILE, filename );
+	return SystemCall( CG_FS_DELETEFILE, filename );
 }
 
 void    trap_SendConsoleCommand( const char *text ) {
-	syscall( CG_SENDCONSOLECOMMAND, text );
+	SystemCall( CG_SENDCONSOLECOMMAND, text );
 }
 
 void    trap_AddCommand( const char *cmdName ) {
-	syscall( CG_ADDCOMMAND, cmdName );
+	SystemCall( CG_ADDCOMMAND, cmdName );
 }
 
 void    trap_RemoveCommand( const char *cmdName ) {
-	syscall( CG_REMOVECOMMAND, cmdName );
+	SystemCall( CG_REMOVECOMMAND, cmdName );
 }
 
 void    trap_SendClientCommand( const char *s ) {
-	syscall( CG_SENDCLIENTCOMMAND, s );
+	SystemCall( CG_SENDCLIENTCOMMAND, s );
 }
 
 void    trap_UpdateScreen( void ) {
-	syscall( CG_UPDATESCREEN );
+	SystemCall( CG_UPDATESCREEN );
 }
 
 /*void	trap_CM_LoadMap( const char *mapname ) {
 	CG_DrawInformation();
-	syscall( CG_CM_LOADMAP, mapname );
+	SystemCall( CG_CM_LOADMAP, mapname );
 }*/
 
 int     trap_CM_NumInlineModels( void ) {
-	return syscall( CG_CM_NUMINLINEMODELS );
+	return SystemCall( CG_CM_NUMINLINEMODELS );
 }
 
 clipHandle_t trap_CM_InlineModel( int index ) {
-	return syscall( CG_CM_INLINEMODEL, index );
+	return SystemCall( CG_CM_INLINEMODEL, index );
 }
 
 clipHandle_t trap_CM_TempBoxModel( const vec3_t mins, const vec3_t maxs ) {
-	return syscall( CG_CM_TEMPBOXMODEL, mins, maxs );
+	return SystemCall( CG_CM_TEMPBOXMODEL, mins, maxs );
 }
 
 clipHandle_t trap_CM_TempCapsuleModel( const vec3_t mins, const vec3_t maxs ) {
-	return syscall( CG_CM_TEMPCAPSULEMODEL, mins, maxs );
+	return SystemCall( CG_CM_TEMPCAPSULEMODEL, mins, maxs );
 }
 
 int     trap_CM_PointContents( const vec3_t p, clipHandle_t model ) {
-	return syscall( CG_CM_POINTCONTENTS, p, model );
+	return SystemCall( CG_CM_POINTCONTENTS, p, model );
 }
 
 int     trap_CM_TransformedPointContents( const vec3_t p, clipHandle_t model, const vec3_t origin, const vec3_t angles ) {
-	return syscall( CG_CM_TRANSFORMEDPOINTCONTENTS, p, model, origin, angles );
+	return SystemCall( CG_CM_TRANSFORMEDPOINTCONTENTS, p, model, origin, angles );
 }
 
 void    trap_CM_BoxTrace( trace_t *results, const vec3_t start, const vec3_t end,
 						  const vec3_t mins, const vec3_t maxs,
 						  clipHandle_t model, int brushmask ) {
-	syscall( CG_CM_BOXTRACE, results, start, end, mins, maxs, model, brushmask );
+	SystemCall( CG_CM_BOXTRACE, results, start, end, mins, maxs, model, brushmask );
 }
 
 void    trap_CM_TransformedBoxTrace( trace_t *results, const vec3_t start, const vec3_t end,
 									 const vec3_t mins, const vec3_t maxs,
 									 clipHandle_t model, int brushmask,
 									 const vec3_t origin, const vec3_t angles ) {
-	syscall( CG_CM_TRANSFORMEDBOXTRACE, results, start, end, mins, maxs, model, brushmask, origin, angles );
+	SystemCall( CG_CM_TRANSFORMEDBOXTRACE, results, start, end, mins, maxs, model, brushmask, origin, angles );
 }
 
 void    trap_CM_CapsuleTrace( trace_t *results, const vec3_t start, const vec3_t end,
 							  const vec3_t mins, const vec3_t maxs,
 							  clipHandle_t model, int brushmask ) {
-	syscall( CG_CM_CAPSULETRACE, results, start, end, mins, maxs, model, brushmask );
+	SystemCall( CG_CM_CAPSULETRACE, results, start, end, mins, maxs, model, brushmask );
 }
 
 void    trap_CM_TransformedCapsuleTrace( trace_t *results, const vec3_t start, const vec3_t end,
 										 const vec3_t mins, const vec3_t maxs,
 										 clipHandle_t model, int brushmask,
 										 const vec3_t origin, const vec3_t angles ) {
-	syscall( CG_CM_TRANSFORMEDCAPSULETRACE, results, start, end, mins, maxs, model, brushmask, origin, angles );
+	SystemCall( CG_CM_TRANSFORMEDCAPSULETRACE, results, start, end, mins, maxs, model, brushmask, origin, angles );
 }
 
 int     trap_CM_MarkFragments( int numPoints, const vec3_t *points,
 							   const vec3_t projection,
 							   int maxPoints, vec3_t pointBuffer,
 							   int maxFragments, markFragment_t *fragmentBuffer ) {
-	return syscall( CG_CM_MARKFRAGMENTS, numPoints, points, projection, maxPoints, pointBuffer, maxFragments, fragmentBuffer );
+	return SystemCall( CG_CM_MARKFRAGMENTS, numPoints, points, projection, maxPoints, pointBuffer, maxFragments, fragmentBuffer );
 }
 
 // ydnar
 void        trap_R_ProjectDecal( qhandle_t hShader, int numPoints, vec3_t *points, vec4_t projection, vec4_t color, int lifeTime, int fadeTime ) {
-	syscall( CG_R_PROJECTDECAL, hShader, numPoints, points, projection, color, lifeTime, fadeTime );
+	SystemCall( CG_R_PROJECTDECAL, hShader, numPoints, points, projection, color, lifeTime, fadeTime );
 }
 
 void        trap_R_ClearDecals( void ) {
-	syscall( CG_R_CLEARDECALS );
+	SystemCall( CG_R_CLEARDECALS );
 }
 
 
 void    trap_S_StartSound( vec3_t origin, int entityNum, int entchannel, sfxHandle_t sfx ) {
-	syscall( CG_S_STARTSOUND, origin, entityNum, entchannel, sfx, 127 /* Gordon: default volume always for the moment*/ );
+	SystemCall( CG_S_STARTSOUND, origin, entityNum, entchannel, sfx, 127 /* Gordon: default volume always for the moment*/ );
 }
 
 void    trap_S_StartSoundVControl( vec3_t origin, int entityNum, int entchannel, sfxHandle_t sfx, int volume ) {
-	syscall( CG_S_STARTSOUND, origin, entityNum, entchannel, sfx, volume );
+	SystemCall( CG_S_STARTSOUND, origin, entityNum, entchannel, sfx, volume );
 }
 
 //----(SA)	added
 void    trap_S_StartSoundEx( vec3_t origin, int entityNum, int entchannel, sfxHandle_t sfx, int flags ) {
-	syscall( CG_S_STARTSOUNDEX, origin, entityNum, entchannel, sfx, flags, 127 /* Gordon: default volume always for the moment*/ );
+	SystemCall( CG_S_STARTSOUNDEX, origin, entityNum, entchannel, sfx, flags, 127 /* Gordon: default volume always for the moment*/ );
 }
 //----(SA)	end
 
 void    trap_S_StartSoundExVControl( vec3_t origin, int entityNum, int entchannel, sfxHandle_t sfx, int flags, int volume ) {
-	syscall( CG_S_STARTSOUNDEX, origin, entityNum, entchannel, sfx, flags, volume );
+	SystemCall( CG_S_STARTSOUNDEX, origin, entityNum, entchannel, sfx, flags, volume );
 }
 
 void    trap_S_StartLocalSound( sfxHandle_t sfx, int channelNum ) {
-	syscall( CG_S_STARTLOCALSOUND, sfx, channelNum, 127 /* Gordon: default volume always for the moment*/ );
+	SystemCall( CG_S_STARTLOCALSOUND, sfx, channelNum, 127 /* Gordon: default volume always for the moment*/ );
 }
 
 void    trap_S_ClearLoopingSounds( void ) {
-	syscall( CG_S_CLEARLOOPINGSOUNDS );
+	SystemCall( CG_S_CLEARLOOPINGSOUNDS );
 }
 
 void    trap_S_ClearSounds( qboolean killmusic ) {
-	syscall( CG_S_CLEARSOUNDS, killmusic );
+	SystemCall( CG_S_CLEARSOUNDS, killmusic );
 }
 
 void    trap_S_AddLoopingSound( const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, int volume, int soundTime ) {
-	syscall( CG_S_ADDLOOPINGSOUND, origin, velocity, 1250, sfx, volume, soundTime );        // volume was previously removed from CG_S_ADDLOOPINGSOUND.  I added 'range'
+	SystemCall( CG_S_ADDLOOPINGSOUND, origin, velocity, 1250, sfx, volume, soundTime );        // volume was previously removed from CG_S_ADDLOOPINGSOUND.  I added 'range'
 }
 
 void    trap_S_AddRealLoopingSound( const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, int range, int volume, int soundTime ) {
-	syscall( CG_S_ADDREALLOOPINGSOUND, origin, velocity, range, sfx, volume, soundTime );
+	SystemCall( CG_S_ADDREALLOOPINGSOUND, origin, velocity, range, sfx, volume, soundTime );
 }
 
 void    trap_S_StopStreamingSound( int entityNum ) {
-	syscall( CG_S_STOPSTREAMINGSOUND, entityNum );
+	SystemCall( CG_S_STOPSTREAMINGSOUND, entityNum );
 }
 
 void    trap_S_UpdateEntityPosition( int entityNum, const vec3_t origin ) {
-	syscall( CG_S_UPDATEENTITYPOSITION, entityNum, origin );
+	SystemCall( CG_S_UPDATEENTITYPOSITION, entityNum, origin );
 }
 
 // Ridah, talking animations
 int     trap_S_GetVoiceAmplitude( int entityNum ) {
-	return syscall( CG_S_GETVOICEAMPLITUDE, entityNum );
+	return SystemCall( CG_S_GETVOICEAMPLITUDE, entityNum );
 }
 // done.
 
 void    trap_S_Respatialize( int entityNum, const vec3_t origin, vec3_t axis[3], int inwater ) {
-	syscall( CG_S_RESPATIALIZE, entityNum, origin, axis, inwater );
+	SystemCall( CG_S_RESPATIALIZE, entityNum, origin, axis, inwater );
 }
 
 /*sfxHandle_t	trap_S_RegisterSound( const char *sample, qboolean compressed ) {
 	CG_DrawInformation();
-	return syscall( CG_S_REGISTERSOUND, sample, compressed );
+	return SystemCall( CG_S_REGISTERSOUND, sample, compressed );
 }*/
 
 int trap_S_GetSoundLength( sfxHandle_t sfx ) {
-	return syscall( CG_S_GETSOUNDLENGTH, sfx );
+	return SystemCall( CG_S_GETSOUNDLENGTH, sfx );
 }
 
 // ydnar: for timing looped sounds
 int trap_S_GetCurrentSoundTime( void ) {
-	return syscall( CG_S_GETCURRENTSOUNDTIME );
+	return SystemCall( CG_S_GETCURRENTSOUNDTIME );
 }
 
 void    trap_S_StartBackgroundTrack( const char *intro, const char *loop, int fadeupTime ) {
-	syscall( CG_S_STARTBACKGROUNDTRACK, intro, loop, fadeupTime );
+	SystemCall( CG_S_STARTBACKGROUNDTRACK, intro, loop, fadeupTime );
 }
 
 void    trap_S_FadeBackgroundTrack( float targetvol, int time, int num ) {   // yes, i know.  fadebackground coming in, fadestreaming going out.  will have to see where functionality leads...
-	syscall( CG_S_FADESTREAMINGSOUND, PASSFLOAT( targetvol ), time, num ); // 'num' is '0' if it's music, '1' if it's "all streaming sounds"
+	SystemCall( CG_S_FADESTREAMINGSOUND, PASSFLOAT( targetvol ), time, num ); // 'num' is '0' if it's music, '1' if it's "all streaming sounds"
 }
 
 void    trap_S_FadeAllSound( float targetvol, int time, qboolean stopsounds ) {
-	syscall( CG_S_FADEALLSOUNDS, PASSFLOAT( targetvol ), time, stopsounds );
+	SystemCall( CG_S_FADEALLSOUNDS, PASSFLOAT( targetvol ), time, stopsounds );
 }
 
 int trap_S_StartStreamingSound( const char *intro, const char *loop, int entnum, int channel, int attenuation ) {
-	return syscall( CG_S_STARTSTREAMINGSOUND, intro, loop, entnum, channel, attenuation );
+	return SystemCall( CG_S_STARTSTREAMINGSOUND, intro, loop, entnum, channel, attenuation );
 }
 
 /*void	trap_R_LoadWorldMap( const char *mapname ) {
 	CG_DrawInformation();
-	syscall( CG_R_LOADWORLDMAP, mapname );
+	SystemCall( CG_R_LOADWORLDMAP, mapname );
 }
 
 qhandle_t trap_R_RegisterModel( const char *name ) {
 	CG_DrawInformation();
-	return syscall( CG_R_REGISTERMODEL, name );
+	return SystemCall( CG_R_REGISTERMODEL, name );
 }*/
 
 //----(SA)	added
 // NOTE: char *name expects an array sized 64 (MAX_QPATH)
 qboolean trap_R_GetSkinModel( qhandle_t skinid, const char *type, char *name ) {
-	return syscall( CG_R_GETSKINMODEL, skinid, type, name );
+	return SystemCall( CG_R_GETSKINMODEL, skinid, type, name );
 }
 
 qhandle_t trap_R_GetShaderFromModel( qhandle_t modelid, int surfnum, int withlightmap ) {
-	return syscall( CG_R_GETMODELSHADER, modelid, surfnum, withlightmap );
+	return SystemCall( CG_R_GETMODELSHADER, modelid, surfnum, withlightmap );
 }
 //----(SA)	end
 
 /*qhandle_t trap_R_RegisterSkin( const char *name ) {
 	CG_DrawInformation();
-	return syscall( CG_R_REGISTERSKIN, name );
+	return SystemCall( CG_R_REGISTERSKIN, name );
 }
 
 qhandle_t trap_R_RegisterShader( const char *name ) {
 	CG_DrawInformation();
-	return syscall( CG_R_REGISTERSHADER, name );
+	return SystemCall( CG_R_REGISTERSHADER, name );
 }
 
 qhandle_t trap_R_RegisterShaderNoMip( const char *name ) {
 	CG_DrawInformation();
-	return syscall( CG_R_REGISTERSHADERNOMIP, name );
+	return SystemCall( CG_R_REGISTERSHADERNOMIP, name );
 }
 
 void trap_R_RegisterFont(const char *fontName, int pointSize, fontInfo_t *font) {
-	syscall(CG_R_REGISTERFONT, fontName, pointSize, font );
+	SystemCall(CG_R_REGISTERFONT, fontName, pointSize, font );
 }*/
 
 void    trap_R_ClearScene( void ) {
-	syscall( CG_R_CLEARSCENE );
+	SystemCall( CG_R_CLEARSCENE );
 }
 
 void    trap_R_AddRefEntityToScene( const refEntity_t *re ) {
-	syscall( CG_R_ADDREFENTITYTOSCENE, re );
+	SystemCall( CG_R_ADDREFENTITYTOSCENE, re );
 }
 
 void    trap_R_AddPolyToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts ) {
-	syscall( CG_R_ADDPOLYTOSCENE, hShader, numVerts, verts );
+	SystemCall( CG_R_ADDPOLYTOSCENE, hShader, numVerts, verts );
 }
 
 void    trap_R_AddPolyBufferToScene( polyBuffer_t* pPolyBuffer ) {
-	syscall( CG_R_ADDPOLYBUFFERTOSCENE, pPolyBuffer );
+	SystemCall( CG_R_ADDPOLYBUFFERTOSCENE, pPolyBuffer );
 }
 
 // Ridah
 void    trap_R_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys ) {
-	syscall( CG_R_ADDPOLYSTOSCENE, hShader, numVerts, verts, numPolys );
+	SystemCall( CG_R_ADDPOLYSTOSCENE, hShader, numVerts, verts, numPolys );
 }
 // done.
 
 // ydnar: new dlight system
 //%	void	trap_R_AddLightToScene( const vec3_t org, float intensity, float r, float g, float b, int overdraw ) {
-//%		syscall( CG_R_ADDLIGHTTOSCENE, org, PASSFLOAT(intensity), PASSFLOAT(r), PASSFLOAT(g), PASSFLOAT(b), overdraw );
+//%		SystemCall( CG_R_ADDLIGHTTOSCENE, org, PASSFLOAT(intensity), PASSFLOAT(r), PASSFLOAT(g), PASSFLOAT(b), overdraw );
 //%	}
 void    trap_R_AddLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags ) {
-	syscall( CG_R_ADDLIGHTTOSCENE, org, PASSFLOAT( radius ), PASSFLOAT( intensity ),
+	SystemCall( CG_R_ADDLIGHTTOSCENE, org, PASSFLOAT( radius ), PASSFLOAT( intensity ),
 			 PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), hShader, flags );
 }
 
 //----(SA)
 void    trap_R_AddCoronaToScene( const vec3_t org, float r, float g, float b, float scale, int id, qboolean visible ) {
-	syscall( CG_R_ADDCORONATOSCENE, org, PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), PASSFLOAT( scale ), id, visible );
+	SystemCall( CG_R_ADDCORONATOSCENE, org, PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), PASSFLOAT( scale ), id, visible );
 }
 //----(SA)
 
 //----(SA)
 void    trap_R_SetFog( int fogvar, int var1, int var2, float r, float g, float b, float density ) {
-	syscall( CG_R_SETFOG, fogvar, var1, var2, PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), PASSFLOAT( density ) );
+	SystemCall( CG_R_SETFOG, fogvar, var1, var2, PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), PASSFLOAT( density ) );
 }
 //----(SA)
 
 void    trap_R_SetGlobalFog( qboolean restore, int duration, float r, float g, float b, float depthForOpaque ) {
-	syscall( CG_R_SETGLOBALFOG, restore, duration, PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), PASSFLOAT( depthForOpaque ) );
+	SystemCall( CG_R_SETGLOBALFOG, restore, duration, PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), PASSFLOAT( depthForOpaque ) );
 }
 
 void    trap_R_RenderScene( const refdef_t *fd ) {
-	syscall( CG_R_RENDERSCENE, fd );
+	SystemCall( CG_R_RENDERSCENE, fd );
 }
 
 // Mad Doctor I, 11/4/2002.
 void    trap_R_SaveViewParms() {
-	syscall( CG_R_SAVEVIEWPARMS );
+	SystemCall( CG_R_SAVEVIEWPARMS );
 }
 
 // Mad Doctor I, 11/4/2002.
 void    trap_R_RestoreViewParms() {
-	syscall( CG_R_RESTOREVIEWPARMS );
+	SystemCall( CG_R_RESTOREVIEWPARMS );
 }
 
 void    trap_R_SetColor( const float *rgba ) {
-	syscall( CG_R_SETCOLOR, rgba );
+	SystemCall( CG_R_SETCOLOR, rgba );
 }
 
 void    trap_R_DrawStretchPic( float x, float y, float w, float h,
 							   float s1, float t1, float s2, float t2, qhandle_t hShader ) {
-	syscall( CG_R_DRAWSTRETCHPIC, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader );
+	SystemCall( CG_R_DRAWSTRETCHPIC, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader );
 }
 
 void    trap_R_DrawRotatedPic( float x, float y, float w, float h,
 							   float s1, float t1, float s2, float t2, qhandle_t hShader, float angle ) {
-	syscall( CG_R_DRAWROTATEDPIC, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader, PASSFLOAT( angle ) );
+	SystemCall( CG_R_DRAWROTATEDPIC, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader, PASSFLOAT( angle ) );
 }
 
 void    trap_R_DrawStretchPicGradient(  float x, float y, float w, float h,
 										float s1, float t1, float s2, float t2, qhandle_t hShader,
 										const float *gradientColor, int gradientType ) {
-	syscall( CG_R_DRAWSTRETCHPIC_GRADIENT, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader, gradientColor, gradientType  );
+	SystemCall( CG_R_DRAWSTRETCHPIC_GRADIENT, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader, gradientColor, gradientType  );
 }
 
 void trap_R_Add2dPolys( polyVert_t* verts, int numverts, qhandle_t hShader ) {
-	syscall( CG_R_DRAW2DPOLYS, verts, numverts, hShader );
+	SystemCall( CG_R_DRAW2DPOLYS, verts, numverts, hShader );
 }
 
 
 void    trap_R_ModelBounds( clipHandle_t model, vec3_t mins, vec3_t maxs ) {
-	syscall( CG_R_MODELBOUNDS, model, mins, maxs );
+	SystemCall( CG_R_MODELBOUNDS, model, mins, maxs );
 }
 
 int     trap_R_LerpTag( orientation_t *tag, const refEntity_t *refent, const char *tagName, int startIndex ) {
-	return syscall( CG_R_LERPTAG, tag, refent, tagName, startIndex );
+	return SystemCall( CG_R_LERPTAG, tag, refent, tagName, startIndex );
 }
 
 void    trap_R_RemapShader( const char *oldShader, const char *newShader, const char *timeOffset ) {
-	syscall( CG_R_REMAP_SHADER, oldShader, newShader, timeOffset );
+	SystemCall( CG_R_REMAP_SHADER, oldShader, newShader, timeOffset );
 }
 
 void        trap_GetGlconfig( glconfig_t *glconfig ) {
-	syscall( CG_GETGLCONFIG, glconfig );
+	SystemCall( CG_GETGLCONFIG, glconfig );
 }
 
 void        trap_GetGameState( gameState_t *gamestate ) {
-	syscall( CG_GETGAMESTATE, gamestate );
+	SystemCall( CG_GETGAMESTATE, gamestate );
 }
 
 #ifdef _DEBUG
@@ -457,7 +457,7 @@ static qboolean skiponeget;
 #endif // _DEBUG
 
 void        trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverTime ) {
-	syscall( CG_GETCURRENTSNAPSHOTNUMBER, snapshotNumber, serverTime );
+	SystemCall( CG_GETCURRENTSNAPSHOTNUMBER, snapshotNumber, serverTime );
 
 #ifdef FAKELAG
 	{
@@ -485,14 +485,14 @@ void        trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverTime 
 
 qboolean    trap_GetSnapshot( int snapshotNumber, snapshot_t *snapshot ) {
 #ifndef FAKELAG
-	return syscall( CG_GETSNAPSHOT, snapshotNumber, snapshot );
+	return SystemCall( CG_GETSNAPSHOT, snapshotNumber, snapshot );
 #else
 	{
 		char s[MAX_STRING_CHARS];
 		int fakeLag;
 
 		if ( skiponeget ) {
-			syscall( CG_GETSNAPSHOT, snapshotNumber, snapshot );
+			SystemCall( CG_GETSNAPSHOT, snapshotNumber, snapshot );
 		}
 
 		trap_Cvar_VariableStringBuffer( "g_fakelag", s, sizeof( s ) );
@@ -533,150 +533,150 @@ qboolean    trap_GetSnapshot( int snapshotNumber, snapshot_t *snapshot ) {
 			//*snapshotNumber = (curSnapshotNumber - 1) & MAX_SNAPSHOT_MASK;
 			return qtrue;
 		} else {
-			return syscall( CG_GETSNAPSHOT, snapshotNumber, snapshot );
+			return SystemCall( CG_GETSNAPSHOT, snapshotNumber, snapshot );
 		}
 	}
 #endif // FAKELAG
 }
 
 qboolean    trap_GetServerCommand( int serverCommandNumber ) {
-	return syscall( CG_GETSERVERCOMMAND, serverCommandNumber );
+	return SystemCall( CG_GETSERVERCOMMAND, serverCommandNumber );
 }
 
 int         trap_GetCurrentCmdNumber( void ) {
-	return syscall( CG_GETCURRENTCMDNUMBER );
+	return SystemCall( CG_GETCURRENTCMDNUMBER );
 }
 
 qboolean    trap_GetUserCmd( int cmdNumber, usercmd_t *ucmd ) {
-	return syscall( CG_GETUSERCMD, cmdNumber, ucmd );
+	return SystemCall( CG_GETUSERCMD, cmdNumber, ucmd );
 }
 
 void        trap_SetUserCmdValue( int stateValue, int flags, float sensitivityScale, int mpIdentClient ) {
-	syscall( CG_SETUSERCMDVALUE, stateValue, flags, PASSFLOAT( sensitivityScale ), mpIdentClient );
+	SystemCall( CG_SETUSERCMDVALUE, stateValue, flags, PASSFLOAT( sensitivityScale ), mpIdentClient );
 }
 
 void        trap_SetClientLerpOrigin( float x, float y, float z ) {
-	syscall( CG_SETCLIENTLERPORIGIN, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( z ) );
+	SystemCall( CG_SETCLIENTLERPORIGIN, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( z ) );
 }
 
 int trap_MemoryRemaining( void ) {
-	return syscall( CG_MEMORY_REMAINING );
+	return SystemCall( CG_MEMORY_REMAINING );
 }
 
 qboolean trap_loadCamera( int camNum, const char *name ) {
-	return syscall( CG_LOADCAMERA, camNum, name );
+	return SystemCall( CG_LOADCAMERA, camNum, name );
 }
 
 void trap_startCamera( int camNum, int time ) {
-	syscall( CG_STARTCAMERA, camNum, time );
+	SystemCall( CG_STARTCAMERA, camNum, time );
 }
 
 void trap_stopCamera( int camNum ) {
-	syscall( CG_STOPCAMERA, camNum );
+	SystemCall( CG_STOPCAMERA, camNum );
 }
 
 qboolean trap_getCameraInfo( int camNum, int time, vec3_t *origin, vec3_t *angles, float *fov ) {
-	return syscall( CG_GETCAMERAINFO, camNum, time, origin, angles, fov );
+	return SystemCall( CG_GETCAMERAINFO, camNum, time, origin, angles, fov );
 }
 
 
 qboolean trap_Key_IsDown( int keynum ) {
-	return syscall( CG_KEY_ISDOWN, keynum );
+	return SystemCall( CG_KEY_ISDOWN, keynum );
 }
 
 int trap_Key_GetCatcher( void ) {
-	return syscall( CG_KEY_GETCATCHER );
+	return SystemCall( CG_KEY_GETCATCHER );
 }
 
 qboolean trap_Key_GetOverstrikeMode( void ) {
-	return syscall( CG_KEY_GETOVERSTRIKEMODE );
+	return SystemCall( CG_KEY_GETOVERSTRIKEMODE );
 }
 
 void trap_Key_SetOverstrikeMode( qboolean state ) {
-	syscall( CG_KEY_SETOVERSTRIKEMODE, state );
+	SystemCall( CG_KEY_SETOVERSTRIKEMODE, state );
 }
 
 // binding MUST be lower case
 void trap_Key_KeysForBinding( const char* binding, int* key1, int* key2 ) {
-	syscall( CG_KEY_BINDINGTOKEYS, binding, key1, key2 );
+	SystemCall( CG_KEY_BINDINGTOKEYS, binding, key1, key2 );
 }
 
 void trap_Key_SetCatcher( int catcher ) {
-	syscall( CG_KEY_SETCATCHER, catcher );
+	SystemCall( CG_KEY_SETCATCHER, catcher );
 }
 
 int trap_Key_GetKey( const char *binding ) {
-	return syscall( CG_KEY_GETKEY, binding );
+	return SystemCall( CG_KEY_GETKEY, binding );
 }
 
 
 int trap_PC_AddGlobalDefine( const char *define ) {
-	return syscall( CG_PC_ADD_GLOBAL_DEFINE, define );
+	return SystemCall( CG_PC_ADD_GLOBAL_DEFINE, define );
 }
 
 int trap_PC_LoadSource( const char *filename ) {
-	return syscall( CG_PC_LOAD_SOURCE, filename );
+	return SystemCall( CG_PC_LOAD_SOURCE, filename );
 }
 
 int trap_PC_FreeSource( int handle ) {
-	return syscall( CG_PC_FREE_SOURCE, handle );
+	return SystemCall( CG_PC_FREE_SOURCE, handle );
 }
 
 int trap_PC_ReadToken( int handle, pc_token_t *pc_token ) {
-	return syscall( CG_PC_READ_TOKEN, handle, pc_token );
+	return SystemCall( CG_PC_READ_TOKEN, handle, pc_token );
 }
 
 int trap_PC_SourceFileAndLine( int handle, char *filename, int *line ) {
-	return syscall( CG_PC_SOURCE_FILE_AND_LINE, handle, filename, line );
+	return SystemCall( CG_PC_SOURCE_FILE_AND_LINE, handle, filename, line );
 }
 
 int trap_PC_UnReadToken( int handle ) {
-	return syscall( CG_PC_UNREAD_TOKEN, handle );
+	return SystemCall( CG_PC_UNREAD_TOKEN, handle );
 }
 
 void    trap_S_StopBackgroundTrack( void ) {
-	syscall( CG_S_STOPBACKGROUNDTRACK );
+	SystemCall( CG_S_STOPBACKGROUNDTRACK );
 }
 
 int trap_RealTime( qtime_t *qtime ) {
-	return syscall( CG_REAL_TIME, qtime );
+	return SystemCall( CG_REAL_TIME, qtime );
 }
 
 void trap_SnapVector( float *v ) {
-	syscall( CG_SNAPVECTOR, v );
+	SystemCall( CG_SNAPVECTOR, v );
 }
 
 // this returns a handle.  arg0 is the name in the format "idlogo.roq", set arg1 to NULL, alteredstates to qfalse (do not alter gamestate)
 int trap_CIN_PlayCinematic( const char *arg0, int xpos, int ypos, int width, int height, int bits ) {
-	return syscall( CG_CIN_PLAYCINEMATIC, arg0, xpos, ypos, width, height, bits );
+	return SystemCall( CG_CIN_PLAYCINEMATIC, arg0, xpos, ypos, width, height, bits );
 }
 
 // stops playing the cinematic and ends it.  should always return FMV_EOF
 // cinematics must be stopped in reverse order of when they are started
 e_status trap_CIN_StopCinematic( int handle ) {
-	return syscall( CG_CIN_STOPCINEMATIC, handle );
+	return SystemCall( CG_CIN_STOPCINEMATIC, handle );
 }
 
 
 // will run a frame of the cinematic but will not draw it.  Will return FMV_EOF if the end of the cinematic has been reached.
 e_status trap_CIN_RunCinematic( int handle ) {
-	return syscall( CG_CIN_RUNCINEMATIC, handle );
+	return SystemCall( CG_CIN_RUNCINEMATIC, handle );
 }
 
 
 // draws the current frame
 void trap_CIN_DrawCinematic( int handle ) {
-	syscall( CG_CIN_DRAWCINEMATIC, handle );
+	SystemCall( CG_CIN_DRAWCINEMATIC, handle );
 }
 
 
 // allows you to resize the animation dynamically
 void trap_CIN_SetExtents( int handle, int x, int y, int w, int h ) {
-	syscall( CG_CIN_SETEXTENTS, handle, x, y, w, h );
+	SystemCall( CG_CIN_SETEXTENTS, handle, x, y, w, h );
 }
 
 qboolean trap_GetEntityToken( char *buffer, int bufferSize ) {
-	return syscall( CG_GET_ENTITY_TOKEN, buffer, bufferSize );
+	return SystemCall( CG_GET_ENTITY_TOKEN, buffer, bufferSize );
 }
 
 //----(SA)	added
@@ -685,27 +685,27 @@ extern void Menus_OpenByName( const char *p );
 
 //void trap_UI_Popup( const char *arg0) {
 void trap_UI_Popup( int arg0 ) {
-	syscall( CG_INGAME_POPUP, arg0 );
+	SystemCall( CG_INGAME_POPUP, arg0 );
 }
 
 void trap_UI_ClosePopup( const char *arg0 ) {
-	syscall( CG_INGAME_CLOSEPOPUP, arg0 );
+	SystemCall( CG_INGAME_CLOSEPOPUP, arg0 );
 }
 
 void trap_Key_GetBindingBuf( int keynum, char *buf, int buflen ) {
-	syscall( CG_KEY_GETBINDINGBUF, keynum, buf, buflen );
+	SystemCall( CG_KEY_GETBINDINGBUF, keynum, buf, buflen );
 }
 
 void trap_Key_SetBinding( int keynum, const char *binding ) {
-	syscall( CG_KEY_SETBINDING, keynum, binding );
+	SystemCall( CG_KEY_SETBINDING, keynum, binding );
 }
 
 void trap_Key_KeynumToStringBuf( int keynum, char *buf, int buflen ) {
-	syscall( CG_KEY_KEYNUMTOSTRINGBUF, keynum, buf, buflen );
+	SystemCall( CG_KEY_KEYNUMTOSTRINGBUF, keynum, buf, buflen );
 }
 
 void trap_TranslateString( const char *string, char *buf ) {
-	syscall( CG_TRANSLATE_STRING, string, buf );
+	SystemCall( CG_TRANSLATE_STRING, string, buf );
 }
 // -NERVE - SMF
 
@@ -717,7 +717,7 @@ sfxHandle_t trap_S_RegisterSound( const char *sample, qboolean compressed ) {
 	sfxHandle_t snd;
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation( qtrue );
-	snd = syscall( CG_S_REGISTERSOUND, sample, qfalse /* compressed */ );
+	snd = SystemCall( CG_S_REGISTERSOUND, sample, qfalse /* compressed */ );
 	if ( !*sample ) {
 		Com_Printf( "^1Warning: Null Sample filename\n" );
 	}
@@ -733,7 +733,7 @@ qhandle_t trap_R_RegisterModel( const char *name ) {
 	qhandle_t handle;
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation( qtrue );
-	handle = syscall( CG_R_REGISTERMODEL, name );
+	handle = SystemCall( CG_R_REGISTERMODEL, name );
 	DEBUG_REGISTERPROFILE_EXEC( "trap_R_RegisterModel",name )
 	trap_PumpEventLoop();
 	return handle;
@@ -743,7 +743,7 @@ qhandle_t trap_R_RegisterSkin( const char *name ) {
 	qhandle_t handle;
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation( qtrue );
-	handle = syscall( CG_R_REGISTERSKIN, name );
+	handle = SystemCall( CG_R_REGISTERSKIN, name );
 	DEBUG_REGISTERPROFILE_EXEC( "trap_R_RegisterSkin",name )
 	trap_PumpEventLoop();
 	return handle;
@@ -753,7 +753,7 @@ qhandle_t trap_R_RegisterShader( const char *name ) {
 	qhandle_t handle;
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation( qtrue );
-	handle = syscall( CG_R_REGISTERSHADER, name );
+	handle = SystemCall( CG_R_REGISTERSHADER, name );
 	DEBUG_REGISTERPROFILE_EXEC( "trap_R_RegisterShader",name )
 	trap_PumpEventLoop();
 	return handle;
@@ -763,7 +763,7 @@ qhandle_t trap_R_RegisterShaderNoMip( const char *name ) {
 	qhandle_t handle;
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation( qtrue );
-	handle = syscall( CG_R_REGISTERSHADERNOMIP, name );
+	handle = SystemCall( CG_R_REGISTERSHADERNOMIP, name );
 	trap_PumpEventLoop();
 	DEBUG_REGISTERPROFILE_EXEC( "trap_R_RegisterShaderNpMip", name );
 	return handle;
@@ -772,7 +772,7 @@ qhandle_t trap_R_RegisterShaderNoMip( const char *name ) {
 void trap_R_RegisterFont( const char *fontName, int pointSize, fontInfo_t *font ) {
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation( qtrue );
-	syscall( CG_R_REGISTERFONT, fontName, pointSize, font );
+	SystemCall( CG_R_REGISTERFONT, fontName, pointSize, font );
 	DEBUG_REGISTERPROFILE_EXEC( "trap_R_RegisterFont",fontName )
 	trap_PumpEventLoop();
 }
@@ -780,7 +780,7 @@ void trap_R_RegisterFont( const char *fontName, int pointSize, fontInfo_t *font 
 void    trap_CM_LoadMap( const char *mapname ) {
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation( qtrue );
-	syscall( CG_CM_LOADMAP, mapname );
+	SystemCall( CG_CM_LOADMAP, mapname );
 	DEBUG_REGISTERPROFILE_EXEC( "trap_CM_LoadMap",mapname )
 	trap_PumpEventLoop();
 }
@@ -788,7 +788,7 @@ void    trap_CM_LoadMap( const char *mapname ) {
 void    trap_R_LoadWorldMap( const char *mapname ) {
 	DEBUG_REGISTERPROFILE_INIT
 	CG_DrawInformation( qtrue );
-	syscall( CG_R_LOADWORLDMAP, mapname );
+	SystemCall( CG_R_LOADWORLDMAP, mapname );
 	DEBUG_REGISTERPROFILE_EXEC( "trap_R_LoadWorldMap",mapname )
 	trap_PumpEventLoop();
 }
@@ -796,106 +796,106 @@ void    trap_R_LoadWorldMap( const char *mapname ) {
 sfxHandle_t trap_S_RegisterSound( const char *sample, qboolean compressed ) {
 	CG_DrawInformation( qtrue );
 	trap_PumpEventLoop();
-	return syscall( CG_S_REGISTERSOUND, sample, qfalse /* compressed */ );
+	return SystemCall( CG_S_REGISTERSOUND, sample, qfalse /* compressed */ );
 }
 
 qhandle_t trap_R_RegisterModel( const char *name ) {
 	CG_DrawInformation( qtrue );
 	trap_PumpEventLoop();
-	return syscall( CG_R_REGISTERMODEL, name );
+	return SystemCall( CG_R_REGISTERMODEL, name );
 }
 
 qhandle_t trap_R_RegisterSkin( const char *name ) {
 	CG_DrawInformation( qtrue );
 	trap_PumpEventLoop();
-	return syscall( CG_R_REGISTERSKIN, name );
+	return SystemCall( CG_R_REGISTERSKIN, name );
 }
 
 qhandle_t trap_R_RegisterShader( const char *name ) {
 	CG_DrawInformation( qtrue );
 	trap_PumpEventLoop();
-	return syscall( CG_R_REGISTERSHADER, name );
+	return SystemCall( CG_R_REGISTERSHADER, name );
 }
 
 qhandle_t trap_R_RegisterShaderNoMip( const char *name ) {
 	CG_DrawInformation( qtrue );
 	trap_PumpEventLoop();
-	return syscall( CG_R_REGISTERSHADERNOMIP, name );
+	return SystemCall( CG_R_REGISTERSHADERNOMIP, name );
 }
 
 void trap_R_RegisterFont( const char *fontName, int pointSize, fontInfo_t *font ) {
 	CG_DrawInformation( qtrue );
 	trap_PumpEventLoop();
-	syscall( CG_R_REGISTERFONT, fontName, pointSize, font );
+	SystemCall( CG_R_REGISTERFONT, fontName, pointSize, font );
 }
 
 void    trap_CM_LoadMap( const char *mapname ) {
 	CG_DrawInformation( qtrue );
 	trap_PumpEventLoop();
-	syscall( CG_CM_LOADMAP, mapname );
+	SystemCall( CG_CM_LOADMAP, mapname );
 }
 
 void    trap_R_LoadWorldMap( const char *mapname ) {
 	CG_DrawInformation( qtrue );
 	trap_PumpEventLoop();
-	syscall( CG_R_LOADWORLDMAP, mapname );
+	SystemCall( CG_R_LOADWORLDMAP, mapname );
 }
 #endif // _DEBUG
 
 qboolean trap_R_inPVS( const vec3_t p1, const vec3_t p2 ) {
-	return syscall( CG_R_INPVS, p1, p2 );
+	return SystemCall( CG_R_INPVS, p1, p2 );
 }
 
 void trap_GetHunkData( int* hunkused, int* hunkexpected ) {
-	syscall( CG_GETHUNKDATA, hunkused, hunkexpected );
+	SystemCall( CG_GETHUNKDATA, hunkused, hunkexpected );
 }
 
 //zinx - binary message channel
 void trap_SendMessage( char *buf, int buflen ) {
-	syscall( CG_SENDMESSAGE, buf, buflen );
+	SystemCall( CG_SENDMESSAGE, buf, buflen );
 }
 
 messageStatus_t trap_MessageStatus( void ) {
-	return syscall( CG_MESSAGESTATUS );
+	return SystemCall( CG_MESSAGESTATUS );
 }
 
 //bani - dynamic shaders
 qboolean trap_R_LoadDynamicShader( const char *shadername, const char *shadertext ) {
-	return syscall( CG_R_LOADDYNAMICSHADER, shadername, shadertext );
+	return SystemCall( CG_R_LOADDYNAMICSHADER, shadername, shadertext );
 }
 
 // fretn - render to texture
 void trap_R_RenderToTexture( int textureid, int x, int y, int w, int h ) {
-	syscall( CG_R_RENDERTOTEXTURE, textureid, x, y, w, h );
+	SystemCall( CG_R_RENDERTOTEXTURE, textureid, x, y, w, h );
 }
 
 int trap_R_GetTextureId( const char *name ) {
-	return syscall( CG_R_GETTEXTUREID, name );
+	return SystemCall( CG_R_GETTEXTUREID, name );
 }
 
 // bani - sync rendering
 void trap_R_Finish( void ) {
-	syscall( CG_R_FINISH );
+	SystemCall( CG_R_FINISH );
 }
 
 // extension interface
 
 qboolean trap_GetValue( char *value, int valueSize, const char *key ) {
-	return syscall( dll_com_trapGetValue, value, valueSize, key );
+	return SystemCall( dll_com_trapGetValue, value, valueSize, key );
 }
 
 void trap_R_AddRefEntityToScene2( const refEntity_t *re ) {
-	syscall( dll_trap_R_AddRefEntityToScene2, re );
+	SystemCall( dll_trap_R_AddRefEntityToScene2, re );
 }
 
 void trap_R_AddLinearLightToScene( const vec3_t start, const vec3_t end, float intensity, float r, float g, float b ) {
-	syscall( dll_trap_R_AddLinearLightToScene, start, end, intensity, r, g, b );
+	SystemCall( dll_trap_R_AddLinearLightToScene, start, end, intensity, r, g, b );
 }
 
 void trap_PC_RemoveAllGlobalDefines( void ) {
-	syscall( dll_trap_PC_RemoveAllGlobalDefines );
+	SystemCall( dll_trap_PC_RemoveAllGlobalDefines );
 }
 
 void trap_GetClipboardData( char *buf, int len ) {
-	syscall( dll_trap_GetClipboardData, buf, len );
+	SystemCall( dll_trap_GetClipboardData, buf, len );
 }

--- a/src/client/cl_cin.c
+++ b/src/client/cl_cin.c
@@ -1502,7 +1502,7 @@ int CIN_PlayCinematic( const char *arg, int x, int y, int w, int h, int systemBi
 	if ( cinTable[currentHandle].alterGameState ) {
 		// close the menu
 		if ( uivm ) {
-			VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_NONE );
+			VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_NONE );
 		}
 	} else {
 		cinTable[currentHandle].playonwalls = cl_inGameVideo->integer;

--- a/src/client/cl_input.c
+++ b/src/client/cl_input.c
@@ -436,7 +436,7 @@ void CL_MouseEvent( int dx, int dy /*, int time*/ ) {
 			cl.mouseDx[cl.mouseIndex] += dx;
 			cl.mouseDy[cl.mouseIndex] += dy;
 		} else {
-			VM_Call( uivm, 2, UI_MOUSE_EVENT, dx, dy );
+			VM_Call( uivm, UI_MOUSE_EVENT, dx, dy );
 		}
 
 	} else if ( Key_GetCatcher() & KEYCATCH_CGAME ) {
@@ -444,7 +444,7 @@ void CL_MouseEvent( int dx, int dy /*, int time*/ ) {
 			cl.mouseDx[cl.mouseIndex] += dx;
 			cl.mouseDy[cl.mouseIndex] += dy;
 		} else {
-			VM_Call( cgvm, 2, CG_MOUSE_EVENT, dx, dy );
+			VM_Call( cgvm, CG_MOUSE_EVENT, dx, dy );
 		}
 	} else {
 		cl.mouseDx[cl.mouseIndex] += dx;

--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -681,13 +681,13 @@ static void CL_KeyDownEvent( int key, unsigned time )
 		// escape always gets out of CGAME stuff
 		if (Key_GetCatcher( ) & KEYCATCH_CGAME) {
 			Key_SetCatcher( Key_GetCatcher( ) & ~KEYCATCH_CGAME );
-			VM_Call( cgvm, 1, CG_EVENT_HANDLING, CGAME_EVENT_NONE );
+			VM_Call( cgvm, CG_EVENT_HANDLING, CGAME_EVENT_NONE );
 			return;
 		}
 
 		if ( !( Key_GetCatcher( ) & KEYCATCH_UI ) ) {
 			if ( cls.state == CA_ACTIVE && !clc.demoplaying ) {
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_INGAME );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_INGAME );
 			}
 			else if ( cls.state != CA_DISCONNECTED ) {
 #if 0
@@ -702,12 +702,12 @@ static void CL_KeyDownEvent( int key, unsigned time )
 					CL_FlushMemory();
 				}
 #endif
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 			}
 			return;
 		}
 
-		VM_Call( uivm, 2, UI_KEY_EVENT, key, qtrue );
+		VM_Call( uivm, UI_KEY_EVENT, key, qtrue );
 		return;
 	}
 
@@ -730,12 +730,12 @@ static void CL_KeyDownEvent( int key, unsigned time )
 			Console_Key( key );
 		}
 	} else if ( (Key_GetCatcher() & KEYCATCH_UI) && uivm && !bypassMenu ) {
-		if ( !onlybinds || VM_Call( uivm, 0, UI_WANTSBINDKEYS ) ) {
-			VM_Call( uivm, 2, UI_KEY_EVENT, key, qtrue );
+		if ( !onlybinds || VM_Call( uivm, UI_WANTSBINDKEYS ) ) {
+			VM_Call( uivm, UI_KEY_EVENT, key, qtrue );
 		}
 	} else if ( (Key_GetCatcher() & KEYCATCH_CGAME) && cgvm && !bypassMenu ) {
-		if ( !onlybinds || VM_Call( cgvm, 0, CG_WANTSBINDKEYS ) ) {
-			VM_Call( cgvm, 2, CG_KEY_EVENT, key, qtrue );
+		if ( !onlybinds || VM_Call( cgvm, CG_WANTSBINDKEYS ) ) {
+			VM_Call( cgvm, CG_KEY_EVENT, key, qtrue );
 		}
 	} else if ( Key_GetCatcher() & KEYCATCH_MESSAGE ) {
 		if ( !onlybinds ) {
@@ -799,12 +799,12 @@ static void CL_KeyUpEvent( int key, unsigned time )
 	}
 
 	if ( Key_GetCatcher( ) & KEYCATCH_UI && uivm ) {
-		if ( !onlybinds || VM_Call( uivm, 0, UI_WANTSBINDKEYS ) ) {
-			VM_Call( uivm, 2, UI_KEY_EVENT, key, qfalse );
+		if ( !onlybinds || VM_Call( uivm, UI_WANTSBINDKEYS ) ) {
+			VM_Call( uivm, UI_KEY_EVENT, key, qfalse );
 		}
 	} else if ( Key_GetCatcher( ) & KEYCATCH_CGAME && cgvm ) {
-		if ( !onlybinds || VM_Call( cgvm, 0, CG_WANTSBINDKEYS ) ) {
-			VM_Call( cgvm, 2, CG_KEY_EVENT, key, qfalse );
+		if ( !onlybinds || VM_Call( cgvm, CG_WANTSBINDKEYS ) ) {
+			VM_Call( cgvm, CG_KEY_EVENT, key, qfalse );
 		}
 	}
 }
@@ -847,11 +847,11 @@ void CL_CharEvent( int key )
 	}
 	else if ( Key_GetCatcher( ) & KEYCATCH_UI )
 	{
-		VM_Call( uivm, 2, UI_KEY_EVENT, key | K_CHAR_FLAG, qtrue );
+		VM_Call( uivm, UI_KEY_EVENT, key | K_CHAR_FLAG, qtrue );
 	}
 	else if ( Key_GetCatcher( ) & KEYCATCH_CGAME )
 	{
-		VM_Call( cgvm, 2, CG_KEY_EVENT, key | K_CHAR_FLAG, qtrue );
+		VM_Call( cgvm, CG_KEY_EVENT, key | K_CHAR_FLAG, qtrue );
 	}
 	else if ( Key_GetCatcher( ) & KEYCATCH_MESSAGE )
 	{

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -1429,7 +1429,7 @@ qboolean CL_Disconnect( qboolean showMainMenu ) {
 	Key_ClearStates();
 
 	if ( uivm && showMainMenu ) {
-		VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_NONE );
+		VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_NONE );
 	}
 
 	// Remove pure paks
@@ -1616,7 +1616,7 @@ void CL_Disconnect_f( void ) {
 				CL_FlushMemory();
 			}
 			if ( uivm ) {
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 			}
 		}
 	}
@@ -3116,7 +3116,7 @@ static void CL_CheckTimeout( void ) {
 				CL_FlushMemory();
 			}
 			if ( uivm ) {
-				VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+				VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 			}
 			return;
 		}
@@ -3335,12 +3335,12 @@ void CL_Frame( int msec, int realMsec ) {
 	if ( cls.cddialog ) {
 		// bring up the cd error dialog if needed
 		cls.cddialog = qfalse;
-		VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_NEED_CD );
+		VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_NEED_CD );
 	} else	if ( cls.state == CA_DISCONNECTED && !( Key_GetCatcher( ) & KEYCATCH_UI )
 		&& !com_sv_running->integer && uivm ) {
 		// if disconnected, bring up the menu
 		S_StopAllSounds();
-		VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+		VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 	}
 
 	aviRecord = CL_VideoRecording();

--- a/src/client/cl_scrn.c
+++ b/src/client/cl_scrn.c
@@ -526,7 +526,7 @@ static void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 
 	re.BeginFrame( stereoFrame );
 
-	uiFullscreen = (uivm && VM_Call( uivm, 0, UI_IS_FULLSCREEN ));
+	uiFullscreen = (uivm && VM_Call( uivm, UI_IS_FULLSCREEN ));
 
 	// wide aspect ratio screens need to have the sides cleared
 	// unless they are displaying game renderings
@@ -556,20 +556,20 @@ static void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 		case CA_DISCONNECTED:
 			// force menu up
 			S_StopAllSounds();
-			VM_Call( uivm, 1, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
+			VM_Call( uivm, UI_SET_ACTIVE_MENU, UIMENU_MAIN );
 			break;
 		case CA_CONNECTING:
 		case CA_CHALLENGING:
 		case CA_CONNECTED:
 			// connecting clients will only show the connection dialog
 			// refresh to update the time
-			VM_Call( uivm, 1, UI_REFRESH, cls.realtime );
-			VM_Call( uivm, 1, UI_DRAW_CONNECT_SCREEN, qfalse );
+			VM_Call( uivm, UI_REFRESH, cls.realtime );
+			VM_Call( uivm, UI_DRAW_CONNECT_SCREEN, qfalse );
 			break;
 //			// Ridah, if the cgame is valid, fall through to there
 //			if (!cls.cgameStarted || !com_sv_running->integer) {
 //				// connecting clients will only show the connection dialog
-//				VM_Call( uivm, 1, UI_DRAW_CONNECT_SCREEN, qfalse );
+//				VM_Call( uivm, UI_DRAW_CONNECT_SCREEN, qfalse );
 //				break;
 //			}
 		case CA_LOADING:
@@ -581,8 +581,8 @@ static void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 			// also draw the connection information, so it doesn't
 			// flash away too briefly on local or lan games
 			// refresh to update the time
-			VM_Call( uivm, 1, UI_REFRESH, cls.realtime );
-			VM_Call( uivm, 1, UI_DRAW_CONNECT_SCREEN, qtrue );
+			VM_Call( uivm, UI_REFRESH, cls.realtime );
+			VM_Call( uivm, UI_DRAW_CONNECT_SCREEN, qtrue );
 			break;
 		case CA_ACTIVE:
 			// always supply STEREO_CENTER as vieworg offset is now done by the engine.
@@ -597,7 +597,7 @@ static void SCR_DrawScreenField( stereoFrame_t stereoFrame ) {
 
 	// the menu draws next
 	if ( (Key_GetCatcher( ) & KEYCATCH_UI) && uivm ) {
-		VM_Call( uivm, 1, UI_REFRESH, cls.realtime );
+		VM_Call( uivm, UI_REFRESH, cls.realtime );
 	}
 
 	// console draws next

--- a/src/game/g_syscalls.c
+++ b/src/game/g_syscalls.c
@@ -44,84 +44,84 @@ int PASSFLOAT( float x ) {
 }
 
 void    trap_Print( const char *fmt ) {
-	syscall( G_PRINT, fmt );
+	SystemCall( G_PRINT, fmt );
 }
 
 void    NORETURN trap_Error( const char *fmt ) {
-	syscall( G_ERROR, fmt );
+	SystemCall( G_ERROR, fmt );
 	exit( 1 );
 }
 
 int     trap_Milliseconds( void ) {
-	return syscall( G_MILLISECONDS );
+	return SystemCall( G_MILLISECONDS );
 }
 int     trap_Argc( void ) {
-	return syscall( G_ARGC );
+	return SystemCall( G_ARGC );
 }
 
 void    trap_Argv( int n, char *buffer, int bufferLength ) {
-	syscall( G_ARGV, n, buffer, bufferLength );
+	SystemCall( G_ARGV, n, buffer, bufferLength );
 }
 
 int     trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode ) {
-	return syscall( G_FS_FOPEN_FILE, qpath, f, mode );
+	return SystemCall( G_FS_FOPEN_FILE, qpath, f, mode );
 }
 
 void    trap_FS_Read( void *buffer, int len, fileHandle_t f ) {
-	syscall( G_FS_READ, buffer, len, f );
+	SystemCall( G_FS_READ, buffer, len, f );
 }
 
 int     trap_FS_Write( const void *buffer, int len, fileHandle_t f ) {
-	return syscall( G_FS_WRITE, buffer, len, f );
+	return SystemCall( G_FS_WRITE, buffer, len, f );
 }
 
 int     trap_FS_Rename( const char *from, const char *to ) {
-	return syscall( G_FS_RENAME, from, to );
+	return SystemCall( G_FS_RENAME, from, to );
 }
 
 void    trap_FS_FCloseFile( fileHandle_t f ) {
-	syscall( G_FS_FCLOSE_FILE, f );
+	SystemCall( G_FS_FCLOSE_FILE, f );
 }
 
 int trap_FS_GetFileList(  const char *path, const char *extension, char *listbuf, int bufsize ) {
-	return syscall( G_FS_GETFILELIST, path, extension, listbuf, bufsize );
+	return SystemCall( G_FS_GETFILELIST, path, extension, listbuf, bufsize );
 }
 
 void    trap_SendConsoleCommand( int exec_when, const char *text ) {
-	syscall( G_SEND_CONSOLE_COMMAND, exec_when, text );
+	SystemCall( G_SEND_CONSOLE_COMMAND, exec_when, text );
 }
 
 void    trap_Cvar_Register( vmCvar_t *cvar, const char *var_name, const char *value, int flags ) {
-	syscall( G_CVAR_REGISTER, cvar, var_name, value, flags );
+	SystemCall( G_CVAR_REGISTER, cvar, var_name, value, flags );
 }
 
 void    trap_Cvar_Update( vmCvar_t *cvar ) {
-	syscall( G_CVAR_UPDATE, cvar );
+	SystemCall( G_CVAR_UPDATE, cvar );
 }
 
 void trap_Cvar_Set( const char *var_name, const char *value ) {
-	syscall( G_CVAR_SET, var_name, value );
+	SystemCall( G_CVAR_SET, var_name, value );
 }
 
 int trap_Cvar_VariableIntegerValue( const char *var_name ) {
-	return syscall( G_CVAR_VARIABLE_INTEGER_VALUE, var_name );
+	return SystemCall( G_CVAR_VARIABLE_INTEGER_VALUE, var_name );
 }
 
 void trap_Cvar_VariableStringBuffer( const char *var_name, char *buffer, int bufsize ) {
-	syscall( G_CVAR_VARIABLE_STRING_BUFFER, var_name, buffer, bufsize );
+	SystemCall( G_CVAR_VARIABLE_STRING_BUFFER, var_name, buffer, bufsize );
 }
 
 void trap_Cvar_LatchedVariableStringBuffer( const char *var_name, char *buffer, int bufsize ) {
-	syscall( G_CVAR_LATCHEDVARIABLESTRINGBUFFER, var_name, buffer, bufsize );
+	SystemCall( G_CVAR_LATCHEDVARIABLESTRINGBUFFER, var_name, buffer, bufsize );
 }
 
 void trap_LocateGameData( gentity_t *gEnts, int numGEntities, int sizeofGEntity_t,
 						  playerState_t *clients, int sizeofGClient ) {
-	syscall( G_LOCATE_GAME_DATA, gEnts, numGEntities, sizeofGEntity_t, clients, sizeofGClient );
+	SystemCall( G_LOCATE_GAME_DATA, gEnts, numGEntities, sizeofGEntity_t, clients, sizeofGClient );
 }
 
 void trap_DropClient( int clientNum, const char *reason, int length ) {
-	syscall( G_DROP_CLIENT, clientNum, reason, length );
+	SystemCall( G_DROP_CLIENT, clientNum, reason, length );
 }
 
 void trap_SendServerCommand( int clientNum, const char *text ) {
@@ -132,105 +132,105 @@ void trap_SendServerCommand( int clientNum, const char *text ) {
 		G_LogPrintf( "%s: text [%s]\n", GAMEVERSION, text );
 		return;
 	}
-	syscall( G_SEND_SERVER_COMMAND, clientNum, text );
+	SystemCall( G_SEND_SERVER_COMMAND, clientNum, text );
 }
 
 void trap_SetConfigstring( int num, const char *string ) {
-	syscall( G_SET_CONFIGSTRING, num, string );
+	SystemCall( G_SET_CONFIGSTRING, num, string );
 }
 
 void trap_GetConfigstring( int num, char *buffer, int bufferSize ) {
-	syscall( G_GET_CONFIGSTRING, num, buffer, bufferSize );
+	SystemCall( G_GET_CONFIGSTRING, num, buffer, bufferSize );
 }
 
 void trap_GetUserinfo( int num, char *buffer, int bufferSize ) {
-	syscall( G_GET_USERINFO, num, buffer, bufferSize );
+	SystemCall( G_GET_USERINFO, num, buffer, bufferSize );
 }
 
 void trap_SetUserinfo( int num, const char *buffer ) {
-	syscall( G_SET_USERINFO, num, buffer );
+	SystemCall( G_SET_USERINFO, num, buffer );
 }
 
 void trap_GetServerinfo( char *buffer, int bufferSize ) {
-	syscall( G_GET_SERVERINFO, buffer, bufferSize );
+	SystemCall( G_GET_SERVERINFO, buffer, bufferSize );
 }
 
 void trap_SetBrushModel( gentity_t *ent, const char *name ) {
-	syscall( G_SET_BRUSH_MODEL, ent, name );
+	SystemCall( G_SET_BRUSH_MODEL, ent, name );
 }
 
 void trap_Trace( trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentmask ) {
-	syscall( G_TRACE, results, start, mins, maxs, end, passEntityNum, contentmask );
+	SystemCall( G_TRACE, results, start, mins, maxs, end, passEntityNum, contentmask );
 }
 
 void trap_TraceNoEnts( trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentmask ) {
-	syscall( G_TRACE, results, start, mins, maxs, end, -2, contentmask );
+	SystemCall( G_TRACE, results, start, mins, maxs, end, -2, contentmask );
 }
 
 void trap_TraceCapsule( trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentmask ) {
-	syscall( G_TRACECAPSULE, results, start, mins, maxs, end, passEntityNum, contentmask );
+	SystemCall( G_TRACECAPSULE, results, start, mins, maxs, end, passEntityNum, contentmask );
 }
 
 void trap_TraceCapsuleNoEnts( trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs, const vec3_t end, int passEntityNum, int contentmask ) {
-	syscall( G_TRACECAPSULE, results, start, mins, maxs, end, -2, contentmask );
+	SystemCall( G_TRACECAPSULE, results, start, mins, maxs, end, -2, contentmask );
 }
 
 int trap_PointContents( const vec3_t point, int passEntityNum ) {
-	return syscall( G_POINT_CONTENTS, point, passEntityNum );
+	return SystemCall( G_POINT_CONTENTS, point, passEntityNum );
 }
 
 
 qboolean trap_InPVS( const vec3_t p1, const vec3_t p2 ) {
-	return syscall( G_IN_PVS, p1, p2 );
+	return SystemCall( G_IN_PVS, p1, p2 );
 }
 
 qboolean trap_InPVSIgnorePortals( const vec3_t p1, const vec3_t p2 ) {
-	return syscall( G_IN_PVS_IGNORE_PORTALS, p1, p2 );
+	return SystemCall( G_IN_PVS_IGNORE_PORTALS, p1, p2 );
 }
 
 void trap_AdjustAreaPortalState( gentity_t *ent, qboolean open ) {
-	syscall( G_ADJUST_AREA_PORTAL_STATE, ent, open );
+	SystemCall( G_ADJUST_AREA_PORTAL_STATE, ent, open );
 }
 
 qboolean trap_AreasConnected( int area1, int area2 ) {
-	return syscall( G_AREAS_CONNECTED, area1, area2 );
+	return SystemCall( G_AREAS_CONNECTED, area1, area2 );
 }
 
 void trap_LinkEntity( gentity_t *ent ) {
-	syscall( G_LINKENTITY, ent );
+	SystemCall( G_LINKENTITY, ent );
 }
 
 void trap_UnlinkEntity( gentity_t *ent ) {
-	syscall( G_UNLINKENTITY, ent );
+	SystemCall( G_UNLINKENTITY, ent );
 }
 
 
 int trap_EntitiesInBox( const vec3_t mins, const vec3_t maxs, int *list, int maxcount ) {
-	return syscall( G_ENTITIES_IN_BOX, mins, maxs, list, maxcount );
+	return SystemCall( G_ENTITIES_IN_BOX, mins, maxs, list, maxcount );
 }
 
 qboolean trap_EntityContact( const vec3_t mins, const vec3_t maxs, const gentity_t *ent ) {
-	return syscall( G_ENTITY_CONTACT, mins, maxs, ent );
+	return SystemCall( G_ENTITY_CONTACT, mins, maxs, ent );
 }
 
 qboolean trap_EntityContactCapsule( const vec3_t mins, const vec3_t maxs, const gentity_t *ent ) {
-	return syscall( G_ENTITY_CONTACTCAPSULE, mins, maxs, ent );
+	return SystemCall( G_ENTITY_CONTACTCAPSULE, mins, maxs, ent );
 }
 
 int trap_BotAllocateClient( int clientNum ) {
-	return syscall( G_BOT_ALLOCATE_CLIENT, clientNum );
+	return SystemCall( G_BOT_ALLOCATE_CLIENT, clientNum );
 }
 
 void trap_BotFreeClient( int clientNum ) {
-	syscall( G_BOT_FREE_CLIENT, clientNum );
+	SystemCall( G_BOT_FREE_CLIENT, clientNum );
 }
 
 int trap_GetSoundLength( sfxHandle_t sfxHandle ) {
-	return syscall( G_GET_SOUND_LENGTH, sfxHandle );
+	return SystemCall( G_GET_SOUND_LENGTH, sfxHandle );
 }
 
 sfxHandle_t trap_RegisterSound( const char *sample, qboolean compressed ) {
-	return syscall( G_REGISTERSOUND, sample, compressed );
+	return SystemCall( G_REGISTERSOUND, sample, compressed );
 }
 
 #ifdef _DEBUG
@@ -245,7 +245,7 @@ static int cmdNumber[MAX_CLIENTS];
 #endif // DEBUG
 
 void trap_GetUsercmd( int clientNum, usercmd_t *cmd ) {
-	syscall( G_GET_USERCMD, clientNum, cmd );
+	SystemCall( G_GET_USERCMD, clientNum, cmd );
 
 #ifdef FAKELAG
 	{
@@ -291,97 +291,97 @@ void trap_GetUsercmd( int clientNum, usercmd_t *cmd ) {
 }
 
 qboolean trap_GetEntityToken( char *buffer, int bufferSize ) {
-	return syscall( G_GET_ENTITY_TOKEN, buffer, bufferSize );
+	return SystemCall( G_GET_ENTITY_TOKEN, buffer, bufferSize );
 }
 
 int trap_DebugPolygonCreate( int color, int numPoints, vec3_t *points ) {
-	return syscall( G_DEBUG_POLYGON_CREATE, color, numPoints, points );
+	return SystemCall( G_DEBUG_POLYGON_CREATE, color, numPoints, points );
 }
 
 void trap_DebugPolygonDelete( int id ) {
-	syscall( G_DEBUG_POLYGON_DELETE, id );
+	SystemCall( G_DEBUG_POLYGON_DELETE, id );
 }
 
 int trap_RealTime( qtime_t *qtime ) {
-	return syscall( G_REAL_TIME, qtime );
+	return SystemCall( G_REAL_TIME, qtime );
 }
 
 void trap_SnapVector( float *v ) {
-	syscall( G_SNAPVECTOR, v );
+	SystemCall( G_SNAPVECTOR, v );
 	return;
 }
 
 qboolean trap_GetTag( int clientNum, int tagFileNumber, char *tagName, orientation_t *or ) {
-	return syscall( G_GETTAG, clientNum, tagFileNumber, tagName, or );
+	return SystemCall( G_GETTAG, clientNum, tagFileNumber, tagName, or );
 }
 
 qboolean trap_LoadTag( const char* filename ) {
-	return syscall( G_REGISTERTAG, filename );
+	return SystemCall( G_REGISTERTAG, filename );
 }
 
 // BotLib traps start here
 int trap_PC_AddGlobalDefine( const char *define ) {
-	return syscall( BOTLIB_PC_ADD_GLOBAL_DEFINE, define );
+	return SystemCall( BOTLIB_PC_ADD_GLOBAL_DEFINE, define );
 }
 
 int trap_PC_LoadSource( const char *filename ) {
-	return syscall( BOTLIB_PC_LOAD_SOURCE, filename );
+	return SystemCall( BOTLIB_PC_LOAD_SOURCE, filename );
 }
 
 int trap_PC_FreeSource( int handle ) {
-	return syscall( BOTLIB_PC_FREE_SOURCE, handle );
+	return SystemCall( BOTLIB_PC_FREE_SOURCE, handle );
 }
 
 int trap_PC_ReadToken( int handle, pc_token_t *pc_token ) {
-	return syscall( BOTLIB_PC_READ_TOKEN, handle, pc_token );
+	return SystemCall( BOTLIB_PC_READ_TOKEN, handle, pc_token );
 }
 
 int trap_PC_SourceFileAndLine( int handle, char *filename, int *line ) {
-	return syscall( BOTLIB_PC_SOURCE_FILE_AND_LINE, handle, filename, line );
+	return SystemCall( BOTLIB_PC_SOURCE_FILE_AND_LINE, handle, filename, line );
 }
 
 int trap_PC_UnReadToken( int handle ) {
-	return syscall( BOTLIB_PC_UNREAD_TOKEN, handle );
+	return SystemCall( BOTLIB_PC_UNREAD_TOKEN, handle );
 }
 
 int trap_BotGetSnapshotEntity( int clientNum, int sequence ) {
-	return syscall( BOTLIB_GET_SNAPSHOT_ENTITY, clientNum, sequence );
+	return SystemCall( BOTLIB_GET_SNAPSHOT_ENTITY, clientNum, sequence );
 }
 
 int trap_BotGetServerCommand( int clientNum, char *message, int size ) {
-	return syscall( BOTLIB_GET_CONSOLE_MESSAGE, clientNum, message, size );
+	return SystemCall( BOTLIB_GET_CONSOLE_MESSAGE, clientNum, message, size );
 }
 
 void trap_BotUserCommand( int clientNum, usercmd_t *ucmd ) {
-	syscall( BOTLIB_USER_COMMAND, clientNum, ucmd );
+	SystemCall( BOTLIB_USER_COMMAND, clientNum, ucmd );
 }
 
 void trap_EA_Command( int client, const char *command ) {
-	syscall( BOTLIB_EA_COMMAND, client, command );
+	SystemCall( BOTLIB_EA_COMMAND, client, command );
 }
 
 void trap_PbStat( int clientNum, const char *category, const char *values ) {
-	syscall( PB_STAT_REPORT, clientNum, category, values ) ;
+	SystemCall( PB_STAT_REPORT, clientNum, category, values ) ;
 }
 
 void trap_SendMessage( int clientNum, char *buf, int buflen ) {
-	syscall( G_SENDMESSAGE, clientNum, buf, buflen );
+	SystemCall( G_SENDMESSAGE, clientNum, buf, buflen );
 }
 
 messageStatus_t trap_MessageStatus( int clientNum ) {
-	return syscall( G_MESSAGESTATUS, clientNum );
+	return SystemCall( G_MESSAGESTATUS, clientNum );
 }
 
 // extension interface
 
 qboolean trap_GetValue( char *value, int valueSize, const char *key ) {
-	return syscall( dll_com_trapGetValue, value, valueSize, key );
+	return SystemCall( dll_com_trapGetValue, value, valueSize, key );
 }
 
 void trap_SV_AddCommand( const char *cmdName ) {
-	syscall( dll_trap_SV_AddCommand, cmdName );
+	SystemCall( dll_trap_SV_AddCommand, cmdName );
 }
 
 void trap_SV_RemoveCommand( const char *cmdName ) {
-	syscall( dll_trap_SV_RemoveCommand, cmdName );
+	SystemCall( dll_trap_SV_RemoveCommand, cmdName );
 }

--- a/src/qcommon/q_shared.h
+++ b/src/qcommon/q_shared.h
@@ -299,6 +299,31 @@ typedef int		clipHandle_t;
 #define ARRAY_LEN(x)		(sizeof(x) / sizeof(*(x)))
 #define STRARRAY_LEN(x)		(ARRAY_LEN(x) - 1)
 
+// We need to use EXPAND because the Microsoft MSVC preprocessor does not expand the va_args the same way as other preprocessors
+// http://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
+#define EXPAND(x) x
+
+#define VM_CALL_END (intptr_t)(-1337)
+#define GET_SYSCALL_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, NAME, ...) NAME
+
+#define SystemCall_0(arg) syscall(arg, VM_CALL_END)
+#define SystemCall_1(arg, a1) syscall(arg, (intptr_t)(a1), VM_CALL_END)
+#define SystemCall_2(arg, a1, a2) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), VM_CALL_END)
+#define SystemCall_3(arg, a1, a2, a3) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), VM_CALL_END)
+#define SystemCall_4(arg, a1, a2, a3, a4) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), VM_CALL_END)
+#define SystemCall_5(arg, a1, a2, a3, a4, a5) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), VM_CALL_END)
+#define SystemCall_6(arg, a1, a2, a3, a4, a5, a6) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), VM_CALL_END)
+#define SystemCall_7(arg, a1, a2, a3, a4, a5, a6, a7) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), VM_CALL_END)
+#define SystemCall_8(arg, a1, a2, a3, a4, a5, a6, a7, a8) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), VM_CALL_END)
+#define SystemCall_9(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), VM_CALL_END)
+#define SystemCall_10(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), VM_CALL_END)
+#define SystemCall_11(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), VM_CALL_END)
+#define SystemCall_12(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), VM_CALL_END)
+#define SystemCall_13(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), (intptr_t)(a13), VM_CALL_END)
+#define SystemCall_14(arg, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14) syscall(arg, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12), (intptr_t)(a13), (intptr_t)(a14), VM_CALL_END)
+
+#define SystemCall(...) EXPAND(GET_SYSCALL_MACRO(__VA_ARGS__, SystemCall_14, SystemCall_13, SystemCall_12, SystemCall_11, SystemCall_10, SystemCall_9, SystemCall_8, SystemCall_7, SystemCall_6, SystemCall_5, SystemCall_4, SystemCall_3, SystemCall_2, SystemCall_1, SystemCall_0)(__VA_ARGS__))
+
 // angle indexes
 #define	PITCH				0		// up / down
 #define	YAW					1		// left / right

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -434,7 +434,25 @@ void	VM_Forced_Unload_Start(void);
 void	VM_Forced_Unload_Done(void);
 vm_t	*VM_Restart( vm_t *vm );
 
-intptr_t	QDECL VM_Call( vm_t *vm, int nargs, int callNum, ... );
+#define GET_VM_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, NAME, ...) NAME
+
+#define VM_Call_0(vm, callNum) VM_CallFunc(vm, 0, callNum)
+#define VM_Call_1(vm, callNum, a1) VM_CallFunc(vm, 1, callNum, (intptr_t)(a1))
+#define VM_Call_2(vm, callNum, a1, a2) VM_CallFunc(vm, 2, callNum, (intptr_t)(a1), (intptr_t)(a2))
+#define VM_Call_3(vm, callNum, a1, a2, a3) VM_CallFunc(vm, 3, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3))
+#define VM_Call_4(vm, callNum, a1, a2, a3, a4) VM_CallFunc(vm, 4, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4))
+#define VM_Call_5(vm, callNum, a1, a2, a3, a4, a5) VM_CallFunc(vm, 5, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5))
+#define VM_Call_6(vm, callNum, a1, a2, a3, a4, a5, a6) VM_CallFunc(vm, 6, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6))
+#define VM_Call_7(vm, callNum, a1, a2, a3, a4, a5, a6, a7) VM_CallFunc(vm, 7, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7))
+#define VM_Call_8(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8) VM_CallFunc(vm, 8, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8))
+#define VM_Call_9(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8, a9) VM_CallFunc(vm, 9, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9))
+#define VM_Call_10(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) VM_CallFunc(vm, 10, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10))
+#define VM_Call_11(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) VM_CallFunc(vm, 11, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11))
+#define VM_Call_12(vm, callNum, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12) VM_CallFunc(vm, 12, callNum, (intptr_t)(a1), (intptr_t)(a2), (intptr_t)(a3), (intptr_t)(a4), (intptr_t)(a5), (intptr_t)(a6), (intptr_t)(a7), (intptr_t)(a8), (intptr_t)(a9), (intptr_t)(a10), (intptr_t)(a11), (intptr_t)(a12))
+
+#define VM_Call(...) EXPAND(GET_VM_MACRO(__VA_ARGS__, VM_Call_12, VM_Call_11, VM_Call_10, VM_Call_9, VM_Call_8, VM_Call_7, VM_Call_6, VM_Call_5, VM_Call_4, VM_Call_3, VM_Call_2, VM_Call_1, VM_Call_0)(__VA_ARGS__))
+
+intptr_t QDECL VM_CallFunc( vm_t *vm, int nargs, int callNum, ... );
 
 void	VM_Debug( int level );
 

--- a/src/qcommon/vm.c
+++ b/src/qcommon/vm.c
@@ -301,7 +301,7 @@ locals from sp
 ==============
 */
 
-intptr_t QDECL VM_Call( vm_t *vm, int nargs, int callnum, ... )
+intptr_t QDECL VM_CallFunc( vm_t *vm, int nargs, int callnum, ... )
 {
 	intptr_t r = 0;
 	int i;

--- a/src/server/sv_bot.c
+++ b/src/server/sv_bot.c
@@ -118,7 +118,7 @@ SV_BotFrame
 	if ( !gvm ) {
 		return;
 	}
-	VM_Call( gvm, 1, BOTAI_START_FRAME, time );
+	VM_Call( gvm, BOTAI_START_FRAME, time );
 }*/
 
 

--- a/src/server/sv_ccmds.c
+++ b/src/server/sv_ccmds.c
@@ -387,7 +387,7 @@ static void SV_MapRestart_f( void ) {
 
 	// run a few frames to allow everything to settle
 	for ( i = 0; i < GAME_INIT_FRAMES; i++ ) {
-		VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+		VM_Call( gvm, GAME_RUN_FRAME, sv.time );
 		sv.time += FRAMETIME;
 	}
 
@@ -416,7 +416,7 @@ static void SV_MapRestart_f( void ) {
 		SV_AddServerCommand( client, "map_restart\n" );
 
 		// connect the client again, without the firstTime flag
-		denied = GVM_ArgPtr( VM_Call( gvm, 3, GAME_CLIENT_CONNECT, i, qfalse, isBot ) );
+		denied = GVM_ArgPtr( VM_Call( gvm, GAME_CLIENT_CONNECT, i, qfalse, isBot ) );
 		if ( denied ) {
 			// this generally shouldn't happen, because the client
 			// was connected before the level change
@@ -437,7 +437,7 @@ static void SV_MapRestart_f( void ) {
 		}
 	}	
 	// run another frame to allow things to look at all the players
-	VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+	VM_Call( gvm, GAME_RUN_FRAME, sv.time );
 	sv.time += FRAMETIME;
 	svs.time += FRAMETIME;
 

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -686,7 +686,7 @@ void SV_DirectConnect( const netadr_t *from ) {
 
 //			// disconnect the client from the game first so any flags the
 //			// player might have are dropped
-//			VM_Call( gvm, 1, GAME_CLIENT_DISCONNECT, newcl - svs.clients );
+//			VM_Call( gvm, GAME_CLIENT_DISCONNECT, newcl - svs.clients );
 			//
 			goto gotnewcl;
 		}
@@ -790,7 +790,7 @@ gotnewcl:
 	}
 
 	// get the game a chance to reject this connection or modify the userinfo
-	denied = VM_Call( gvm, 3, GAME_CLIENT_CONNECT, clientNum, qtrue, qfalse ); // firstTime = qtrue
+	denied = VM_Call( gvm, GAME_CLIENT_CONNECT, clientNum, qtrue, qfalse ); // firstTime = qtrue
 	if ( denied ) {
 		// we can't just use VM_ArgPtr, because that is only valid inside a VM_Call
 		const char *str = GVM_ArgPtr( denied );
@@ -890,7 +890,7 @@ void SV_DropClient( client_t *drop, const char *reason ) {
 
 	// call the prog function for removing a client
 	// this will remove the body, among other things
-	VM_Call( gvm, 1, GAME_CLIENT_DISCONNECT, drop - svs.clients );
+	VM_Call( gvm, GAME_CLIENT_DISCONNECT, drop - svs.clients );
 
 	// add the disconnect command
 	if ( reason ) {
@@ -1149,7 +1149,7 @@ void SV_ClientEnterWorld( client_t *client, usercmd_t *cmd ) {
 		memset(&client->lastUsercmd, '\0', sizeof(client->lastUsercmd));
 
 	// call the game begin function
-	VM_Call( gvm, 1, GAME_CLIENT_BEGIN, client - svs.clients );
+	VM_Call( gvm, GAME_CLIENT_BEGIN, client - svs.clients );
 }
 
 
@@ -2026,7 +2026,7 @@ static void SV_UpdateUserinfo_f( client_t *cl ) {
 
 	SV_UserinfoChanged( cl, qtrue, qtrue ); // update userinfo, run filter
 	// call prog code to allow overrides
-	VM_Call( gvm, 1, GAME_CLIENT_USERINFO_CHANGED, cl - svs.clients );
+	VM_Call( gvm, GAME_CLIENT_USERINFO_CHANGED, cl - svs.clients );
 }
 
 extern int SV_Strlen( const char *str );
@@ -2213,7 +2213,7 @@ qboolean SV_ExecuteClientCommand( client_t *cl, const char *s, qboolean premapre
 				else
 					Cmd_Args_Sanitize( "\n\r", qtrue );
 			}
-			VM_Call( gvm, 1, GAME_CLIENT_COMMAND, cl - svs.clients );
+			VM_Call( gvm, GAME_CLIENT_COMMAND, cl - svs.clients );
 		}
 	}
 
@@ -2275,7 +2275,7 @@ void SV_ClientThink (client_t *cl, usercmd_t *cmd) {
 		return;		// may have been kicked during the last usercmd
 	}
 
-	VM_Call( gvm, 1, GAME_CLIENT_THINK, cl - svs.clients );
+	VM_Call( gvm, GAME_CLIENT_THINK, cl - svs.clients );
 }
 
 

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -356,14 +356,14 @@ SV_GameBinaryMessageReceived
 void SV_GameBinaryMessageReceived( int cno, const char *buf, int buflen, int commandTime ) {
 	if ( !gvm )
 		return;
-	VM_Call( gvm, 4, GAME_MESSAGERECEIVED, cno, buf, buflen, commandTime );
+	VM_Call( gvm, GAME_MESSAGERECEIVED, cno, buf, buflen, commandTime );
 }
 
 
 qboolean SV_GameSnapshotCallback( int entityNum, int clientNum ) {
 	if ( !gvm )
 		return qtrue;
-	return VM_Call( gvm, 2, GAME_SNAPSHOT_CALLBACK, entityNum, clientNum );
+	return VM_Call( gvm, GAME_SNAPSHOT_CALLBACK, entityNum, clientNum );
 }
 
 
@@ -711,14 +711,23 @@ SV_DllSyscall
 */
 static intptr_t QDECL SV_DllSyscall( intptr_t arg, ... ) {
 #if !id386 || defined __clang__
-	intptr_t	args[14]; // max.count for qagame
+	intptr_t	args[15]; // max.count for qagame + WM_CALL_END
 	va_list	ap;
 	int i;
+	size_t len = ARRAY_LEN(args);
 
 	args[0] = arg;
 	va_start( ap, arg );
-	for (i = 1; i < ARRAY_LEN( args ); i++ )
-		args[ i ] = va_arg( ap, intptr_t );
+
+	for (i = 1; i < len; i++) {
+		args[i] = va_arg(ap, intptr_t);
+
+		if (VM_CALL_END == (int)args[i]) {
+			args[i] = 0;
+			break;
+		}
+	}
+
 	va_end( ap );
 
 	return SV_GameSystemCalls( args );
@@ -754,7 +763,7 @@ void SV_ShutdownGameProgs( void ) {
 
 	//Sys_OmnibotUnLoad();
 
-	VM_Call( gvm, 1, GAME_SHUTDOWN, qfalse );
+	VM_Call( gvm, GAME_SHUTDOWN, qfalse );
 	VM_Free( gvm );
 	gvm = NULL;
 	Cmd_UnregisterModule( MODULE_SGAME );
@@ -790,9 +799,9 @@ static void SV_InitGameVM( qboolean restart ) {
 	// use the current msec count for a random seed
 	// init for this gamestate
 	if ( currentGameMod == GAMEMOD_LEGACY )
-		VM_Call( gvm, 5, GAME_INIT, sv.time, Com_Milliseconds(), restart, qtrue, com_legacyVersion->integer );
+		VM_Call( gvm, GAME_INIT, sv.time, Com_Milliseconds(), restart, qtrue, com_legacyVersion->integer );
 	else
-		VM_Call( gvm, 3, GAME_INIT, sv.time, Com_Milliseconds(), restart );
+		VM_Call( gvm, GAME_INIT, sv.time, Com_Milliseconds(), restart );
 }
 
 
@@ -811,7 +820,7 @@ void SV_RestartGameProgs( void ) {
 	// unload the refs during a restart
 	//Sys_OmnibotUnLoad();
 
-	VM_Call( gvm, 1, GAME_SHUTDOWN, qtrue );
+	VM_Call( gvm, GAME_SHUTDOWN, qtrue );
 
 	// do a restart instead of a free
 	gvm = VM_Restart( gvm );
@@ -865,7 +874,7 @@ qboolean SV_GameCommand( void ) {
 		return qfalse;
 	}
 
-	return VM_Call( gvm, 0, GAME_CONSOLE_COMMAND );
+	return VM_Call( gvm, GAME_CONSOLE_COMMAND );
 }
 
 /*

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -701,7 +701,7 @@ void SV_SpawnServer( const char *mapname ) {
 	// run a few frames to allow everything to settle
 	for ( i = 0 ; i < GAME_INIT_FRAMES ; i++ )
 	{
-		VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+		VM_Call( gvm, GAME_RUN_FRAME, sv.time );
         sv.time += FRAMETIME;
 		////SV_BotFrame (sv.time);
 	}
@@ -726,7 +726,7 @@ void SV_SpawnServer( const char *mapname ) {
 			}
 
 			// connect the client again
-			denied = GVM_ArgPtr( VM_Call( gvm, 3, GAME_CLIENT_CONNECT, i, qfalse, isBot ) );	// firstTime = qfalse
+			denied = GVM_ArgPtr( VM_Call( gvm, GAME_CLIENT_CONNECT, i, qfalse, isBot ) );	// firstTime = qfalse
 			if ( denied ) {
 				// this generally shouldn't happen, because the client
 				// was connected before the level change
@@ -750,14 +750,14 @@ void SV_SpawnServer( const char *mapname ) {
 					client->deltaMessage = client->netchan.outgoingSequence - ( PACKET_BACKUP + 1 ); // force delta reset
 					client->lastSnapshotTime = svs.time - 9999; // generate a snapshot immediately
 
-					VM_Call( gvm, 1, GAME_CLIENT_BEGIN, i );
+					VM_Call( gvm, GAME_CLIENT_BEGIN, i );
 				}
 			}
 		}
 	}
 
 	// run another frame to allow things to look at all the players
-	VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+	VM_Call( gvm, GAME_RUN_FRAME, sv.time );
 	sv.time += FRAMETIME;
 	////SV_BotFrame( sv.time );
 	svs.time += FRAMETIME;

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -1669,7 +1669,7 @@ void SV_Frame( int msec ) {
 		sv.time += frameMsec;
 
 		// let everything in the world think and move
-		VM_Call( gvm, 1, GAME_RUN_FRAME, sv.time );
+		VM_Call( gvm, GAME_RUN_FRAME, sv.time );
 	}
 
 	if ( com_speeds->integer ) {

--- a/src/ui/ui_syscalls.c
+++ b/src/ui/ui_syscalls.c
@@ -44,179 +44,179 @@ int PASSFLOAT( float x ) {
 }
 
 void trap_Print( const char *string ) {
-	syscall( UI_PRINT, string );
+	SystemCall( UI_PRINT, string );
 }
 
 void NORETURN trap_Error( const char *string ) {
-	syscall( UI_ERROR, string );
+	SystemCall( UI_ERROR, string );
 	exit( 1 );
 }
 
 int trap_Milliseconds( void ) {
-	return syscall( UI_MILLISECONDS );
+	return SystemCall( UI_MILLISECONDS );
 }
 
 void trap_Cvar_Register( vmCvar_t *cvar, const char *var_name, const char *value, int flags ) {
-	syscall( UI_CVAR_REGISTER, cvar, var_name, value, flags );
+	SystemCall( UI_CVAR_REGISTER, cvar, var_name, value, flags );
 }
 
 void trap_Cvar_Update( vmCvar_t *cvar ) {
-	syscall( UI_CVAR_UPDATE, cvar );
+	SystemCall( UI_CVAR_UPDATE, cvar );
 }
 
 void trap_Cvar_Set( const char *var_name, const char *value ) {
-	syscall( UI_CVAR_SET, var_name, value );
+	SystemCall( UI_CVAR_SET, var_name, value );
 }
 
 float trap_Cvar_VariableValue( const char *var_name ) {
 	floatint_t temp;
-	temp.i = syscall( UI_CVAR_VARIABLEVALUE, var_name );
+	temp.i = SystemCall( UI_CVAR_VARIABLEVALUE, var_name );
 	return temp.f;
 }
 
 void trap_Cvar_VariableStringBuffer( const char *var_name, char *buffer, int bufsize ) {
-	syscall( UI_CVAR_VARIABLESTRINGBUFFER, var_name, buffer, bufsize );
+	SystemCall( UI_CVAR_VARIABLESTRINGBUFFER, var_name, buffer, bufsize );
 }
 
 void trap_Cvar_LatchedVariableStringBuffer( const char *var_name, char *buffer, int bufsize ) {
-	syscall( UI_CVAR_LATCHEDVARIABLESTRINGBUFFER, var_name, buffer, bufsize );
+	SystemCall( UI_CVAR_LATCHEDVARIABLESTRINGBUFFER, var_name, buffer, bufsize );
 }
 
 void trap_Cvar_SetValue( const char *var_name, float value ) {
-	syscall( UI_CVAR_SETVALUE, var_name, PASSFLOAT( value ) );
+	SystemCall( UI_CVAR_SETVALUE, var_name, PASSFLOAT( value ) );
 }
 
 void trap_Cvar_Reset( const char *name ) {
-	syscall( UI_CVAR_RESET, name );
+	SystemCall( UI_CVAR_RESET, name );
 }
 
 void trap_Cvar_Create( const char *var_name, const char *var_value, int flags ) {
-	syscall( UI_CVAR_CREATE, var_name, var_value, flags );
+	SystemCall( UI_CVAR_CREATE, var_name, var_value, flags );
 }
 
 void trap_Cvar_InfoStringBuffer( int bit, char *buffer, int bufsize ) {
-	syscall( UI_CVAR_INFOSTRINGBUFFER, bit, buffer, bufsize );
+	SystemCall( UI_CVAR_INFOSTRINGBUFFER, bit, buffer, bufsize );
 }
 
 int trap_Argc( void ) {
-	return syscall( UI_ARGC );
+	return SystemCall( UI_ARGC );
 }
 
 void trap_Argv( int n, char *buffer, int bufferLength ) {
-	syscall( UI_ARGV, n, buffer, bufferLength );
+	SystemCall( UI_ARGV, n, buffer, bufferLength );
 }
 
 void trap_Cmd_ExecuteText( int exec_when, const char *text ) {
-	syscall( UI_CMD_EXECUTETEXT, exec_when, text );
+	SystemCall( UI_CMD_EXECUTETEXT, exec_when, text );
 }
 
 void trap_AddCommand( const char *cmdName ) {
-	syscall( UI_ADDCOMMAND, cmdName );
+	SystemCall( UI_ADDCOMMAND, cmdName );
 }
 
 int trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode ) {
-	return syscall( UI_FS_FOPENFILE, qpath, f, mode );
+	return SystemCall( UI_FS_FOPENFILE, qpath, f, mode );
 }
 
 void trap_FS_Read( void *buffer, int len, fileHandle_t f ) {
-	syscall( UI_FS_READ, buffer, len, f );
+	SystemCall( UI_FS_READ, buffer, len, f );
 }
 
 void trap_FS_Write( const void *buffer, int len, fileHandle_t f ) {
-	syscall( UI_FS_WRITE, buffer, len, f );
+	SystemCall( UI_FS_WRITE, buffer, len, f );
 }
 
 void trap_FS_FCloseFile( fileHandle_t f ) {
-	syscall( UI_FS_FCLOSEFILE, f );
+	SystemCall( UI_FS_FCLOSEFILE, f );
 }
 
 int trap_FS_GetFileList(  const char *path, const char *extension, char *listbuf, int bufsize ) {
-	return syscall( UI_FS_GETFILELIST, path, extension, listbuf, bufsize );
+	return SystemCall( UI_FS_GETFILELIST, path, extension, listbuf, bufsize );
 }
 
 int trap_FS_Delete( const char *filename ) {
-	return syscall( UI_FS_DELETEFILE, filename );
+	return SystemCall( UI_FS_DELETEFILE, filename );
 }
 
 qhandle_t trap_R_RegisterModel( const char *name ) {
-	return syscall( UI_R_REGISTERMODEL, name );
+	return SystemCall( UI_R_REGISTERMODEL, name );
 }
 
 qhandle_t trap_R_RegisterSkin( const char *name ) {
-	return syscall( UI_R_REGISTERSKIN, name );
+	return SystemCall( UI_R_REGISTERSKIN, name );
 }
 
 void trap_R_RegisterFont( const char *fontName, int pointSize, fontInfo_t *font ) {
-	syscall( UI_R_REGISTERFONT, fontName, pointSize, font );
+	SystemCall( UI_R_REGISTERFONT, fontName, pointSize, font );
 }
 
 qhandle_t trap_R_RegisterShaderNoMip( const char *name ) {
-	return syscall( UI_R_REGISTERSHADERNOMIP, name );
+	return SystemCall( UI_R_REGISTERSHADERNOMIP, name );
 }
 
 void trap_R_ClearScene( void ) {
-	syscall( UI_R_CLEARSCENE );
+	SystemCall( UI_R_CLEARSCENE );
 }
 
 void trap_R_AddRefEntityToScene( const refEntity_t *re ) {
-	syscall( UI_R_ADDREFENTITYTOSCENE, re );
+	SystemCall( UI_R_ADDREFENTITYTOSCENE, re );
 }
 
 void trap_R_AddPolyToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts ) {
-	syscall( UI_R_ADDPOLYTOSCENE, hShader, numVerts, verts );
+	SystemCall( UI_R_ADDPOLYTOSCENE, hShader, numVerts, verts );
 }
 
 // ydnar: new dlight system
 //%	void	trap_R_AddLightToScene( const vec3_t org, float intensity, float r, float g, float b, int overdraw ) {
-//%		syscall( UI_R_ADDLIGHTTOSCENE, org, PASSFLOAT(intensity), PASSFLOAT(r), PASSFLOAT(g), PASSFLOAT(b), overdraw );
+//%		SystemCall( UI_R_ADDLIGHTTOSCENE, org, PASSFLOAT(intensity), PASSFLOAT(r), PASSFLOAT(g), PASSFLOAT(b), overdraw );
 //%	}
 void    trap_R_AddLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags ) {
-	syscall( UI_R_ADDLIGHTTOSCENE, org, PASSFLOAT( radius ), PASSFLOAT( intensity ),
+	SystemCall( UI_R_ADDLIGHTTOSCENE, org, PASSFLOAT( radius ), PASSFLOAT( intensity ),
 			 PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), hShader, flags );
 }
 
 void trap_R_AddCoronaToScene( const vec3_t org, float r, float g, float b, float scale, int id, qboolean visible ) {
-	syscall( UI_R_ADDCORONATOSCENE, org, PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), PASSFLOAT( scale ), id, visible  );
+	SystemCall( UI_R_ADDCORONATOSCENE, org, PASSFLOAT( r ), PASSFLOAT( g ), PASSFLOAT( b ), PASSFLOAT( scale ), id, visible  );
 }
 
 void trap_R_RenderScene( const refdef_t *fd ) {
-	syscall( UI_R_RENDERSCENE, fd );
+	SystemCall( UI_R_RENDERSCENE, fd );
 }
 
 void trap_R_SetColor( const float *rgba ) {
-	syscall( UI_R_SETCOLOR, rgba );
+	SystemCall( UI_R_SETCOLOR, rgba );
 }
 
 void trap_R_Add2dPolys( polyVert_t* verts, int numverts, qhandle_t hShader ) {
-	syscall( UI_R_DRAW2DPOLYS, verts, numverts, hShader );
+	SystemCall( UI_R_DRAW2DPOLYS, verts, numverts, hShader );
 }
 
 void trap_R_DrawStretchPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader ) {
-	syscall( UI_R_DRAWSTRETCHPIC, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader );
+	SystemCall( UI_R_DRAWSTRETCHPIC, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader );
 }
 
 void trap_R_DrawRotatedPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader, float angle ) {
-	syscall( UI_R_DRAWROTATEDPIC, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader, PASSFLOAT( angle ) );
+	SystemCall( UI_R_DRAWROTATEDPIC, PASSFLOAT( x ), PASSFLOAT( y ), PASSFLOAT( w ), PASSFLOAT( h ), PASSFLOAT( s1 ), PASSFLOAT( t1 ), PASSFLOAT( s2 ), PASSFLOAT( t2 ), hShader, PASSFLOAT( angle ) );
 }
 
 void trap_R_ModelBounds( clipHandle_t model, vec3_t mins, vec3_t maxs ) {
-	syscall( UI_R_MODELBOUNDS, model, mins, maxs );
+	SystemCall( UI_R_MODELBOUNDS, model, mins, maxs );
 }
 
 void trap_UpdateScreen( void ) {
-	syscall( UI_UPDATESCREEN );
+	SystemCall( UI_UPDATESCREEN );
 }
 
 int trap_CM_LerpTag( orientation_t *tag, const refEntity_t *refent, const char *tagName, int startIndex ) {
-	return syscall( UI_CM_LERPTAG, tag, refent, tagName, 0 );           // NEFVE - SMF - fixed
+	return SystemCall( UI_CM_LERPTAG, tag, refent, tagName, 0 );           // NEFVE - SMF - fixed
 }
 
 void trap_S_StartLocalSound( sfxHandle_t sfx, int channelNum ) {
-	syscall( UI_S_STARTLOCALSOUND, sfx, channelNum, 127 /* Gordon: default volume always for the moment*/ );
+	SystemCall( UI_S_STARTLOCALSOUND, sfx, channelNum, 127 /* Gordon: default volume always for the moment*/ );
 }
 
 sfxHandle_t trap_S_RegisterSound( const char *sample, qboolean compressed ) {
-	int i = syscall( UI_S_REGISTERSOUND, sample, qfalse /* compressed */ );
+	int i = SystemCall( UI_S_REGISTERSOUND, sample, qfalse /* compressed */ );
 #ifdef _DEBUG
 	if ( i == 0 ) {
 		Com_Printf( "^1Warning: Failed to load sound: %s\n", sample );
@@ -226,268 +226,268 @@ sfxHandle_t trap_S_RegisterSound( const char *sample, qboolean compressed ) {
 }
 
 void    trap_S_FadeBackgroundTrack( float targetvol, int time, int num ) {   // yes, i know.  fadebackground coming in, fadestreaming going out.  will have to see where functionality leads...
-	syscall( UI_S_FADESTREAMINGSOUND, PASSFLOAT( targetvol ), time, num ); // 'num' is '0' if it's music, '1' if it's "all streaming sounds"
+	SystemCall( UI_S_FADESTREAMINGSOUND, PASSFLOAT( targetvol ), time, num ); // 'num' is '0' if it's music, '1' if it's "all streaming sounds"
 }
 
 void    trap_S_FadeAllSound( float targetvol, int time, qboolean stopsound ) {
-	syscall( UI_S_FADEALLSOUNDS, PASSFLOAT( targetvol ), time, stopsound );
+	SystemCall( UI_S_FADEALLSOUNDS, PASSFLOAT( targetvol ), time, stopsound );
 }
 
 void trap_Key_KeynumToStringBuf( int keynum, char *buf, int buflen ) {
-	syscall( UI_KEY_KEYNUMTOSTRINGBUF, keynum, buf, buflen );
+	SystemCall( UI_KEY_KEYNUMTOSTRINGBUF, keynum, buf, buflen );
 }
 
 void trap_Key_GetBindingBuf( int keynum, char *buf, int buflen ) {
-	syscall( UI_KEY_GETBINDINGBUF, keynum, buf, buflen );
+	SystemCall( UI_KEY_GETBINDINGBUF, keynum, buf, buflen );
 }
 
 // binding MUST be lower case
 void trap_Key_KeysForBinding( const char* binding, int* key1, int* key2 ) {
-	syscall( UI_KEY_BINDINGTOKEYS, binding, key1, key2 );
+	SystemCall( UI_KEY_BINDINGTOKEYS, binding, key1, key2 );
 }
 
 void trap_Key_SetBinding( int keynum, const char *binding ) {
-	syscall( UI_KEY_SETBINDING, keynum, binding );
+	SystemCall( UI_KEY_SETBINDING, keynum, binding );
 }
 
 qboolean trap_Key_IsDown( int keynum ) {
-	return syscall( UI_KEY_ISDOWN, keynum );
+	return SystemCall( UI_KEY_ISDOWN, keynum );
 }
 
 qboolean trap_Key_GetOverstrikeMode( void ) {
-	return syscall( UI_KEY_GETOVERSTRIKEMODE );
+	return SystemCall( UI_KEY_GETOVERSTRIKEMODE );
 }
 
 void trap_Key_SetOverstrikeMode( qboolean state ) {
-	syscall( UI_KEY_SETOVERSTRIKEMODE, state );
+	SystemCall( UI_KEY_SETOVERSTRIKEMODE, state );
 }
 
 void trap_Key_ClearStates( void ) {
-	syscall( UI_KEY_CLEARSTATES );
+	SystemCall( UI_KEY_CLEARSTATES );
 }
 
 int trap_Key_GetCatcher( void ) {
-	return syscall( UI_KEY_GETCATCHER );
+	return SystemCall( UI_KEY_GETCATCHER );
 }
 
 void trap_Key_SetCatcher( int catcher ) {
-	syscall( UI_KEY_SETCATCHER, catcher );
+	SystemCall( UI_KEY_SETCATCHER, catcher );
 }
 
 void trap_GetClipboardData( char *buf, int bufsize ) {
-	syscall( UI_GETCLIPBOARDDATA, buf, bufsize );
+	SystemCall( UI_GETCLIPBOARDDATA, buf, bufsize );
 }
 
 void trap_GetClientState( uiClientState_t *state ) {
-	syscall( UI_GETCLIENTSTATE, state );
+	SystemCall( UI_GETCLIENTSTATE, state );
 }
 
 void trap_GetGlconfig( glconfig_t *glconfig ) {
-	syscall( UI_GETGLCONFIG, glconfig );
+	SystemCall( UI_GETGLCONFIG, glconfig );
 }
 
 int trap_GetConfigString( int index, char* buff, int buffsize ) {
-	return syscall( UI_GETCONFIGSTRING, index, buff, buffsize );
+	return SystemCall( UI_GETCONFIGSTRING, index, buff, buffsize );
 }
 
 int trap_LAN_GetLocalServerCount( void ) {
-	return syscall( UI_LAN_GETLOCALSERVERCOUNT );
+	return SystemCall( UI_LAN_GETLOCALSERVERCOUNT );
 }
 
 void trap_LAN_GetLocalServerAddressString( int n, char *buf, int buflen ) {
-	syscall( UI_LAN_GETLOCALSERVERADDRESSSTRING, n, buf, buflen );
+	SystemCall( UI_LAN_GETLOCALSERVERADDRESSSTRING, n, buf, buflen );
 }
 
 int trap_LAN_GetGlobalServerCount( void ) {
-	return syscall( UI_LAN_GETGLOBALSERVERCOUNT );
+	return SystemCall( UI_LAN_GETGLOBALSERVERCOUNT );
 }
 
 void trap_LAN_GetGlobalServerAddressString( int n, char *buf, int buflen ) {
-	syscall( UI_LAN_GETGLOBALSERVERADDRESSSTRING, n, buf, buflen );
+	SystemCall( UI_LAN_GETGLOBALSERVERADDRESSSTRING, n, buf, buflen );
 }
 
 int trap_LAN_GetPingQueueCount( void ) {
-	return syscall( UI_LAN_GETPINGQUEUECOUNT );
+	return SystemCall( UI_LAN_GETPINGQUEUECOUNT );
 }
 
 void trap_LAN_ClearPing( int n ) {
-	syscall( UI_LAN_CLEARPING, n );
+	SystemCall( UI_LAN_CLEARPING, n );
 }
 
 void trap_LAN_GetPing( int n, char *buf, int buflen, int *pingtime ) {
-	syscall( UI_LAN_GETPING, n, buf, buflen, pingtime );
+	SystemCall( UI_LAN_GETPING, n, buf, buflen, pingtime );
 }
 
 void trap_LAN_GetPingInfo( int n, char *buf, int buflen ) {
-	syscall( UI_LAN_GETPINGINFO, n, buf, buflen );
+	SystemCall( UI_LAN_GETPINGINFO, n, buf, buflen );
 }
 
 // NERVE - SMF
 qboolean trap_LAN_UpdateVisiblePings( int source ) {
-	return syscall( UI_LAN_UPDATEVISIBLEPINGS, source );
+	return SystemCall( UI_LAN_UPDATEVISIBLEPINGS, source );
 }
 
 int trap_LAN_GetServerCount( int source ) {
-	return syscall( UI_LAN_GETSERVERCOUNT, source );
+	return SystemCall( UI_LAN_GETSERVERCOUNT, source );
 }
 
 int trap_LAN_CompareServers( int source, int sortKey, int sortDir, int s1, int s2 ) {
-	return syscall( UI_LAN_COMPARESERVERS, source, sortKey, sortDir, s1, s2 );
+	return SystemCall( UI_LAN_COMPARESERVERS, source, sortKey, sortDir, s1, s2 );
 }
 
 void trap_LAN_GetServerAddressString( int source, int n, char *buf, int buflen ) {
-	syscall( UI_LAN_GETSERVERADDRESSSTRING, source, n, buf, buflen );
+	SystemCall( UI_LAN_GETSERVERADDRESSSTRING, source, n, buf, buflen );
 }
 
 void trap_LAN_GetServerInfo( int source, int n, char *buf, int buflen ) {
-	syscall( UI_LAN_GETSERVERINFO, source, n, buf, buflen );
+	SystemCall( UI_LAN_GETSERVERINFO, source, n, buf, buflen );
 }
 
 int trap_LAN_AddServer( int source, const char *name, const char *addr ) {
-	return syscall( UI_LAN_ADDSERVER, source, name, addr );
+	return SystemCall( UI_LAN_ADDSERVER, source, name, addr );
 }
 
 void trap_LAN_RemoveServer( int source, const char *addr ) {
-	syscall( UI_LAN_REMOVESERVER, source, addr );
+	SystemCall( UI_LAN_REMOVESERVER, source, addr );
 }
 
 int trap_LAN_GetServerPing( int source, int n ) {
-	return syscall( UI_LAN_GETSERVERPING, source, n );
+	return SystemCall( UI_LAN_GETSERVERPING, source, n );
 }
 
 int trap_LAN_ServerIsVisible( int source, int n ) {
-	return syscall( UI_LAN_SERVERISVISIBLE, source, n );
+	return SystemCall( UI_LAN_SERVERISVISIBLE, source, n );
 }
 
 int trap_LAN_ServerStatus( const char *serverAddress, char *serverStatus, int maxLen ) {
-	return syscall( UI_LAN_SERVERSTATUS, serverAddress, serverStatus, maxLen );
+	return SystemCall( UI_LAN_SERVERSTATUS, serverAddress, serverStatus, maxLen );
 }
 
 qboolean trap_LAN_ServerIsInFavoriteList( int source, int n  ) {
-	return syscall( UI_LAN_SERVERISINFAVORITELIST, source, n );
+	return SystemCall( UI_LAN_SERVERISINFAVORITELIST, source, n );
 }
 
 void trap_LAN_SaveCachedServers() {
-	syscall( UI_LAN_SAVECACHEDSERVERS );
+	SystemCall( UI_LAN_SAVECACHEDSERVERS );
 }
 
 void trap_LAN_LoadCachedServers() {
-	syscall( UI_LAN_LOADCACHEDSERVERS );
+	SystemCall( UI_LAN_LOADCACHEDSERVERS );
 }
 
 void trap_LAN_MarkServerVisible( int source, int n, qboolean visible ) {
-	syscall( UI_LAN_MARKSERVERVISIBLE, source, n, visible );
+	SystemCall( UI_LAN_MARKSERVERVISIBLE, source, n, visible );
 }
 
 // DHM - Nerve :: PunkBuster
 void trap_SetPbClStatus( int status ) {
-	syscall( UI_SET_PBCLSTATUS, status );
+	SystemCall( UI_SET_PBCLSTATUS, status );
 }
 // DHM - Nerve
 
 // TTimo: also for Sv
 void trap_SetPbSvStatus( int status ) {
-	syscall( UI_SET_PBSVSTATUS, status );
+	SystemCall( UI_SET_PBSVSTATUS, status );
 }
 
 void trap_LAN_ResetPings( int n ) {
-	syscall( UI_LAN_RESETPINGS, n );
+	SystemCall( UI_LAN_RESETPINGS, n );
 }
 // -NERVE - SMF
 
 int trap_MemoryRemaining( void ) {
-	return syscall( UI_MEMORY_REMAINING );
+	return SystemCall( UI_MEMORY_REMAINING );
 }
 
 void trap_GetCDKey( char *buf, int buflen ) {
-	syscall( UI_GET_CDKEY, buf, buflen );
+	SystemCall( UI_GET_CDKEY, buf, buflen );
 }
 
 void trap_SetCDKey( char *buf ) {
-	syscall( UI_SET_CDKEY, buf );
+	SystemCall( UI_SET_CDKEY, buf );
 }
 
 int trap_PC_AddGlobalDefine( const char *define ) {
-	return syscall( UI_PC_ADD_GLOBAL_DEFINE, define );
+	return SystemCall( UI_PC_ADD_GLOBAL_DEFINE, define );
 }
 
 void trap_PC_RemoveAllGlobalDefines( void ) {
-	syscall( UI_PC_REMOVE_ALL_GLOBAL_DEFINES );
+	SystemCall( UI_PC_REMOVE_ALL_GLOBAL_DEFINES );
 }
 
 int trap_PC_LoadSource( const char *filename ) {
-	return syscall( UI_PC_LOAD_SOURCE, filename );
+	return SystemCall( UI_PC_LOAD_SOURCE, filename );
 }
 
 int trap_PC_FreeSource( int handle ) {
-	return syscall( UI_PC_FREE_SOURCE, handle );
+	return SystemCall( UI_PC_FREE_SOURCE, handle );
 }
 
 int trap_PC_ReadToken( int handle, pc_token_t *pc_token ) {
-	return syscall( UI_PC_READ_TOKEN, handle, pc_token );
+	return SystemCall( UI_PC_READ_TOKEN, handle, pc_token );
 }
 
 int trap_PC_SourceFileAndLine( int handle, char *filename, int *line ) {
-	return syscall( UI_PC_SOURCE_FILE_AND_LINE, handle, filename, line );
+	return SystemCall( UI_PC_SOURCE_FILE_AND_LINE, handle, filename, line );
 }
 
 int trap_PC_UnReadToken( int handle ) {
-	return syscall( UI_PC_UNREAD_TOKEN, handle );
+	return SystemCall( UI_PC_UNREAD_TOKEN, handle );
 }
 
 void trap_S_StopBackgroundTrack( void ) {
-	syscall( UI_S_STOPBACKGROUNDTRACK );
+	SystemCall( UI_S_STOPBACKGROUNDTRACK );
 }
 
 void trap_S_StartBackgroundTrack( const char *intro, const char *loop, int fadeupTime ) {
-	syscall( UI_S_STARTBACKGROUNDTRACK, intro, loop, fadeupTime );
+	SystemCall( UI_S_STARTBACKGROUNDTRACK, intro, loop, fadeupTime );
 }
 
 int trap_RealTime( qtime_t *qtime ) {
-	return syscall( UI_REAL_TIME, qtime );
+	return SystemCall( UI_REAL_TIME, qtime );
 }
 
 // this returns a handle.  arg0 is the name in the format "idlogo.roq", set arg1 to NULL, alteredstates to qfalse (do not alter gamestate)
 int trap_CIN_PlayCinematic( const char *arg0, int xpos, int ypos, int width, int height, int bits ) {
-	return syscall( UI_CIN_PLAYCINEMATIC, arg0, xpos, ypos, width, height, bits );
+	return SystemCall( UI_CIN_PLAYCINEMATIC, arg0, xpos, ypos, width, height, bits );
 }
 
 // stops playing the cinematic and ends it.  should always return FMV_EOF
 // cinematics must be stopped in reverse order of when they are started
 e_status trap_CIN_StopCinematic( int handle ) {
-	return syscall( UI_CIN_STOPCINEMATIC, handle );
+	return SystemCall( UI_CIN_STOPCINEMATIC, handle );
 }
 
 
 // will run a frame of the cinematic but will not draw it.  Will return FMV_EOF if the end of the cinematic has been reached.
 e_status trap_CIN_RunCinematic( int handle ) {
-	return syscall( UI_CIN_RUNCINEMATIC, handle );
+	return SystemCall( UI_CIN_RUNCINEMATIC, handle );
 }
 
 
 // draws the current frame
 void trap_CIN_DrawCinematic( int handle ) {
-	syscall( UI_CIN_DRAWCINEMATIC, handle );
+	SystemCall( UI_CIN_DRAWCINEMATIC, handle );
 }
 
 
 // allows you to resize the animation dynamically
 void trap_CIN_SetExtents( int handle, int x, int y, int w, int h ) {
-	syscall( UI_CIN_SETEXTENTS, handle, x, y, w, h );
+	SystemCall( UI_CIN_SETEXTENTS, handle, x, y, w, h );
 }
 
 
 void    trap_R_RemapShader( const char *oldShader, const char *newShader, const char *timeOffset ) {
-	syscall( UI_R_REMAP_SHADER, oldShader, newShader, timeOffset );
+	SystemCall( UI_R_REMAP_SHADER, oldShader, newShader, timeOffset );
 }
 
 qboolean trap_VerifyCDKey( const char *key, const char *chksum ) {
-	return syscall( UI_VERIFY_CDKEY, key, chksum );
+	return SystemCall( UI_VERIFY_CDKEY, key, chksum );
 }
 
 // NERVE - SMF
 qboolean trap_GetLimboString( int index, char *buf ) {
-	return syscall( UI_CL_GETLIMBOSTRING, index, buf );
+	return SystemCall( UI_CL_GETLIMBOSTRING, index, buf );
 }
 
 #define MAX_VA_STRING       32000
@@ -500,7 +500,7 @@ char* trap_TranslateString( const char *string ) {
 	buf = staticbuf[bufcount++ % 2];
 
 #ifdef LOCALIZATION_SUPPORT
-	syscall( UI_CL_TRANSLATE_STRING, string, buf );
+	SystemCall( UI_CL_TRANSLATE_STRING, string, buf );
 #else
 	Q_strncpyz( buf, string, MAX_VA_STRING );
 #endif // LOCALIZATION_SUPPORT
@@ -510,36 +510,36 @@ char* trap_TranslateString( const char *string ) {
 
 // DHM - Nerve
 void trap_CheckAutoUpdate( void ) {
-	syscall( UI_CHECKAUTOUPDATE );
+	SystemCall( UI_CHECKAUTOUPDATE );
 }
 
 void trap_GetAutoUpdate( void ) {
-	syscall( UI_GET_AUTOUPDATE );
+	SystemCall( UI_GET_AUTOUPDATE );
 }
 // DHM - Nerve
 
 void trap_openURL( const char *s ) {
-	syscall( UI_OPENURL, s );
+	SystemCall( UI_OPENURL, s );
 }
 
 void trap_GetHunkData( int* hunkused, int* hunkexpected ) {
-	syscall( UI_GETHUNKDATA, hunkused, hunkexpected );
+	SystemCall( UI_GETHUNKDATA, hunkused, hunkexpected );
 }
 
 // extension interface
 
 qboolean trap_GetValue( char *value, int valueSize, const char *key ) {
-	return syscall( dll_com_trapGetValue, value, valueSize, key );
+	return SystemCall( dll_com_trapGetValue, value, valueSize, key );
 }
 
 void trap_R_AddRefEntityToScene2( const refEntity_t *re ) {
-	syscall( dll_trap_R_AddRefEntityToScene2, re );
+	SystemCall( dll_trap_R_AddRefEntityToScene2, re );
 }
 
 void trap_R_AddLinearLightToScene( const vec3_t start, const vec3_t end, float intensity, float r, float g, float b ) {
-	syscall( dll_trap_R_AddLinearLightToScene, start, end, intensity, r, g, b );
+	SystemCall( dll_trap_R_AddLinearLightToScene, start, end, intensity, r, g, b );
 }
 
 void trap_RemoveCommand( const char *cmdName ) {
-	syscall( dll_trap_RemoveCommand, cmdName );
+	SystemCall( dll_trap_RemoveCommand, cmdName );
 }


### PR DESCRIPTION
Every argument needs to be cast to intptr_t to ensure the memory is correctly aligned for va_arg as it reads everything as intptr_t to support both x86 and x64 correctly.