### PR TITLE
Fix crash on Wayland when renderer was shutdown on fullscreen

### DIFF
--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -68,7 +68,12 @@ void GLimp_Shutdown( qboolean unloadDLL )
 	SDL_DestroyWindow( SDL_window );
 	SDL_window = NULL;
 
-	if ( glw_state.isFullscreen )
+	if ( glw_state.isFullscreen
+#ifdef __linux__
+		// wayland does not support 'SDL_WarpMouseGlobal' and crashes if called
+		&& Q_stricmp(SDL_GetCurrentVideoDriver(), "wayland")
+#endif
+	)
 		SDL_WarpMouseGlobal( glw_state.desktop_width / 2, glw_state.desktop_height / 2 );
 
 	if ( unloadDLL )


### PR DESCRIPTION
Wayland does not support mouse warping, and in turn `SDL_WarpMouseGlobal`, which causes the game to crash when for example using `vid_restart` in fullscreen.